### PR TITLE
test: Follow the conventions for the tests

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -109,12 +109,6 @@ parameters:
 			path: src/PhpSpecAdapterFactory.php
 
 		-
-			message: '#^Method Infection\\Tests\\TestFramework\\PhpSpec\\Adapter\\VersionParserTest\:\:versionProvider\(\) return type has no value type specified in iterable type iterable\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/phpunit/Adapter/VersionParserTest.php
-
-		-
 			message: '#^Cannot access offset ''PhpSpecCodeCoverageExtension'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 3
@@ -173,3 +167,9 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: tests/phpunit/Config/MutationYamlConfigurationTest.php
+
+		-
+			message: '#^Method Infection\\Tests\\TestFramework\\PhpSpec\\VersionParserTest\:\:versionProvider\(\) return type has no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/phpunit/VersionParserTest.php

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,6 +6,7 @@
          executionOrder="random"
          cacheDirectory="var/phpunit-cache"
          displayDetailsOnSkippedTests="true"
+         requireCoverageMetadata="true"
          displayDetailsOnTestsThatTriggerDeprecations="true"
          displayDetailsOnPhpunitDeprecations="true"
          displayDetailsOnTestsThatTriggerNotices="true"

--- a/tests/phpunit/CommandLine/ArgumentsAndOptionsBuilderTest.php
+++ b/tests/phpunit/CommandLine/ArgumentsAndOptionsBuilderTest.php
@@ -36,8 +36,10 @@ declare(strict_types=1);
 namespace Infection\Tests\TestFramework\PhpSpec\CommandLine;
 
 use Infection\TestFramework\PhpSpec\CommandLine\ArgumentsAndOptionsBuilder;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(ArgumentsAndOptionsBuilder::class)]
 final class ArgumentsAndOptionsBuilderTest extends TestCase
 {
     public function test_it_builds_correct_command(): void

--- a/tests/phpunit/Config/Builder/InitialConfigBuilderTest.php
+++ b/tests/phpunit/Config/Builder/InitialConfigBuilderTest.php
@@ -37,9 +37,11 @@ namespace Infection\Tests\TestFramework\PhpSpec\Config\Builder;
 
 use Infection\TestFramework\PhpSpec\Config\Builder\InitialConfigBuilder;
 use Infection\Tests\TestFramework\PhpSpec\FileSystem\FileSystemTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 
 #[Group('integration')]
+#[CoversClass(InitialConfigBuilder::class)]
 final class InitialConfigBuilderTest extends FileSystemTestCase
 {
     public function test_it_builds_path_to_initial_config_file(): void

--- a/tests/phpunit/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/phpunit/Config/Builder/MutationConfigBuilderTest.php
@@ -37,10 +37,12 @@ namespace Infection\Tests\TestFramework\PhpSpec\Config\Builder;
 
 use Infection\TestFramework\PhpSpec\Config\Builder\MutationConfigBuilder;
 use Infection\Tests\TestFramework\PhpSpec\FileSystem\FileSystemTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use function Safe\file_get_contents;
 
 #[Group('integration')]
+#[CoversClass(MutationConfigBuilder::class)]
 final class MutationConfigBuilderTest extends FileSystemTestCase
 {
     private const MUTATION_HASH = 'a1b2c3';

--- a/tests/phpunit/Config/InitialYamlConfigurationTest.php
+++ b/tests/phpunit/Config/InitialYamlConfigurationTest.php
@@ -36,12 +36,16 @@ declare(strict_types=1);
 namespace Infection\Tests\TestFramework\PhpSpec\Config;
 
 use function count;
+use Infection\TestFramework\PhpSpec\Config\AbstractYamlConfiguration;
 use Infection\TestFramework\PhpSpec\Config\InitialYamlConfiguration;
 use Infection\TestFramework\PhpSpec\Config\NoCodeCoverageException;
 use Infection\TestFramework\PhpSpec\PhpSpecAdapter;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Yaml\Yaml;
 
+#[CoversClass(AbstractYamlConfiguration::class)]
+#[CoversClass(InitialYamlConfiguration::class)]
 final class InitialYamlConfigurationTest extends TestCase
 {
     private string $tempDir = '/path/to/tmp';

--- a/tests/phpunit/Config/MutationYamlConfigurationTest.php
+++ b/tests/phpunit/Config/MutationYamlConfigurationTest.php
@@ -36,10 +36,14 @@ declare(strict_types=1);
 namespace Infection\Tests\TestFramework\PhpSpec\Config;
 
 use function count;
+use Infection\TestFramework\PhpSpec\Config\AbstractYamlConfiguration;
 use Infection\TestFramework\PhpSpec\Config\MutationYamlConfiguration;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Yaml\Yaml;
 
+#[CoversClass(AbstractYamlConfiguration::class)]
+#[CoversClass(MutationYamlConfiguration::class)]
 final class MutationYamlConfigurationTest extends TestCase
 {
     private string $tempDir = '/path/to/tmp';

--- a/tests/phpunit/Config/NoCodeCoverageExceptionTest.php
+++ b/tests/phpunit/Config/NoCodeCoverageExceptionTest.php
@@ -36,8 +36,10 @@ declare(strict_types=1);
 namespace Infection\Tests\TestFramework\PhpSpec\Config;
 
 use Infection\TestFramework\PhpSpec\Config\NoCodeCoverageException;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(NoCodeCoverageException::class)]
 final class NoCodeCoverageExceptionTest extends TestCase
 {
     public function test_from_test_framework(): void

--- a/tests/phpunit/FinderExceptionTest.php
+++ b/tests/phpunit/FinderExceptionTest.php
@@ -33,11 +33,13 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\TestFramework\PhpSpec\Adapter;
+namespace Infection\Tests\TestFramework\PhpSpec;
 
 use Infection\TestFramework\PhpSpec\FinderException;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(FinderException::class)]
 final class FinderExceptionTest extends TestCase
 {
     public function test_php_executable_not_found(): void

--- a/tests/phpunit/PhpSpecAdapterFactoryTest.php
+++ b/tests/phpunit/PhpSpecAdapterFactoryTest.php
@@ -33,14 +33,16 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\TestFramework\PhpSpec\Adapter;
+namespace Infection\Tests\TestFramework\PhpSpec;
 
 use Infection\TestFramework\PhpSpec\PhpSpecAdapter;
 use Infection\TestFramework\PhpSpec\PhpSpecAdapterFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 #[Group('integration')]
+#[CoversClass(PhpSpecAdapterFactory::class)]
 final class PhpSpecAdapterFactoryTest extends TestCase
 {
     public function test_it_creates_phpspec_adapter(): void

--- a/tests/phpunit/PhpSpecAdapterTest.php
+++ b/tests/phpunit/PhpSpecAdapterTest.php
@@ -33,7 +33,7 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\TestFramework\PhpSpec\Adapter;
+namespace Infection\Tests\TestFramework\PhpSpec;
 
 use Infection\AbstractTestFramework\Coverage\TestLocation;
 use Infection\TestFramework\PhpSpec\CommandLine\ArgumentsAndOptionsBuilder;
@@ -42,9 +42,11 @@ use Infection\TestFramework\PhpSpec\Config\Builder\InitialConfigBuilder;
 use Infection\TestFramework\PhpSpec\Config\Builder\MutationConfigBuilder;
 use Infection\TestFramework\PhpSpec\PhpSpecAdapter;
 use Infection\TestFramework\PhpSpec\VersionParser;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use function sprintf;
 
+#[CoversClass(PhpSpecAdapter::class)]
 final class PhpSpecAdapterTest extends TestCase
 {
     public function test_it_has_a_name(): void

--- a/tests/phpunit/VersionParserTest.php
+++ b/tests/phpunit/VersionParserTest.php
@@ -33,13 +33,15 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\TestFramework\PhpSpec\Adapter;
+namespace Infection\Tests\TestFramework\PhpSpec;
 
 use Infection\TestFramework\PhpSpec\VersionParser;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(VersionParser::class)]
 final class VersionParserTest extends TestCase
 {
     private VersionParser $versionParser;


### PR DESCRIPTION
- Move the tests to the right location.
- Add the coverage metadata.