### PR TITLE
feat: Throw a dedicated exception when the version could not be parsed

### DIFF
--- a/src/Throwable/UnrecognisableTestFrameworkVersion.php
+++ b/src/Throwable/UnrecognisableTestFrameworkVersion.php
@@ -33,33 +33,21 @@
 
 declare(strict_types=1);
 
-namespace Infection\TestFramework\PhpSpec;
+namespace Infection\TestFramework\PhpSpec\Throwable;
 
-use Infection\TestFramework\PhpSpec\Throwable\UnrecognisableTestFrameworkVersion;
-use function preg_match;
+use RuntimeException;
+use function sprintf;
 
-/**
- * @internal
- */
-class VersionParser
+final class UnrecognisableTestFrameworkVersion extends RuntimeException
 {
-    private const VERSION_REGEX = '/(?<version>\d+\.\d+\.?\d*)(?<prerelease>-[\d\p{L}.]+)?(?<build>\+[\d\p{L}.]+)?/';
-
-    /**
-     * @throws UnrecognisableTestFrameworkVersion
-     */
-    public function parse(string $value): string
+    public static function create(string $testFrameworkName, string $version): self
     {
-        $matches = [];
-        $matched = preg_match(self::VERSION_REGEX, $value, $matches) > 0;
-
-        if (!$matched) {
-            throw UnrecognisableTestFrameworkVersion::create(
-                'PhpSpec',
-                $value,
-            );
-        }
-
-        return $matches[0];
+        return new self(
+            sprintf(
+                'Could not recognise the test framework version for %s for the value "%s".',
+                $testFrameworkName,
+                $version,
+            ),
+        );
     }
 }

--- a/src/Throwable/UnrecognisableTestFrameworkVersion.php
+++ b/src/Throwable/UnrecognisableTestFrameworkVersion.php
@@ -35,10 +35,10 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework\PhpSpec\Throwable;
 
-use RuntimeException;
 use function sprintf;
+use UnexpectedValueException;
 
-final class UnrecognisableTestFrameworkVersion extends RuntimeException
+final class UnrecognisableTestFrameworkVersion extends UnexpectedValueException
 {
     public static function create(string $testFrameworkName, string $version): self
     {

--- a/tests/phpunit/Throwable/UnrecognisableTestFrameworkVersionTest.php
+++ b/tests/phpunit/Throwable/UnrecognisableTestFrameworkVersionTest.php
@@ -33,33 +33,25 @@
 
 declare(strict_types=1);
 
-namespace Infection\TestFramework\PhpSpec;
+namespace Infection\Tests\TestFramework\PhpSpec\Throwable;
 
 use Infection\TestFramework\PhpSpec\Throwable\UnrecognisableTestFrameworkVersion;
-use function preg_match;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
 
-/**
- * @internal
- */
-class VersionParser
+#[CoversClass(UnrecognisableTestFrameworkVersion::class)]
+final class UnrecognisableTestFrameworkVersionTest extends TestCase
 {
-    private const VERSION_REGEX = '/(?<version>\d+\.\d+\.?\d*)(?<prerelease>-[\d\p{L}.]+)?(?<build>\+[\d\p{L}.]+)?/';
-
-    /**
-     * @throws UnrecognisableTestFrameworkVersion
-     */
-    public function parse(string $value): string
+    public function test_it_can_create_an_exception(): void
     {
-        $matches = [];
-        $matched = preg_match(self::VERSION_REGEX, $value, $matches) > 0;
+        $exception = UnrecognisableTestFrameworkVersion::create(
+            'PhpSpec',
+            'dev-main',
+        );
 
-        if (!$matched) {
-            throw UnrecognisableTestFrameworkVersion::create(
-                'PhpSpec',
-                $value,
-            );
-        }
-
-        return $matches[0];
+        $this->assertSame(
+            'Could not recognise the test framework version for PhpSpec for the value "dev-main".',
+            $exception->getMessage(),
+        );
     }
 }

--- a/tests/phpunit/VersionParserTest.php
+++ b/tests/phpunit/VersionParserTest.php
@@ -36,8 +36,8 @@ declare(strict_types=1);
 namespace Infection\Tests\TestFramework\PhpSpec;
 
 use Exception;
+use Infection\TestFramework\PhpSpec\Throwable\UnrecognisableTestFrameworkVersion;
 use Infection\TestFramework\PhpSpec\VersionParser;
-use InvalidArgumentException;
 use function is_array;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -181,7 +181,7 @@ final class VersionParserTest extends TestCase
         // https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
         yield [
             '1',
-            new InvalidArgumentException('Parameter does not contain a valid SemVer (sub)string.'),
+            UnrecognisableTestFrameworkVersion::create('PhpSpec', '1'),
         ];
 
         yield '1.2';
@@ -194,74 +194,74 @@ final class VersionParserTest extends TestCase
 
         yield [
             '+invalid',
-            new InvalidArgumentException('Parameter does not contain a valid SemVer (sub)string.'),
+            UnrecognisableTestFrameworkVersion::create('PhpSpec', '+invalid'),
         ];
 
         yield [
             '-invalid',
-            new InvalidArgumentException('Parameter does not contain a valid SemVer (sub)string.'),
+            UnrecognisableTestFrameworkVersion::create('PhpSpec', '-invalid'),
         ];
 
         yield [
             '-invalid+invalid',
-            new InvalidArgumentException('Parameter does not contain a valid SemVer (sub)string.'),
+            UnrecognisableTestFrameworkVersion::create('PhpSpec', '-invalid+invalid'),
         ];
 
         yield [
             '-invalid.01',
-            new InvalidArgumentException('Parameter does not contain a valid SemVer (sub)string.'),
+            UnrecognisableTestFrameworkVersion::create('PhpSpec', '-invalid.01'),
         ];
 
         yield [
             'alpha',
-            new InvalidArgumentException('Parameter does not contain a valid SemVer (sub)string.'),
+            UnrecognisableTestFrameworkVersion::create('PhpSpec', 'alpha'),
         ];
 
         yield [
             'alpha.beta',
-            new InvalidArgumentException('Parameter does not contain a valid SemVer (sub)string.'),
+            UnrecognisableTestFrameworkVersion::create('PhpSpec', 'alpha.beta'),
         ];
 
         yield [
             'alpha.beta.1',
-            new InvalidArgumentException('Parameter does not contain a valid SemVer (sub)string.'),
+            UnrecognisableTestFrameworkVersion::create('PhpSpec', 'alpha.beta.1'),
         ];
 
         yield [
             'alpha.1',
-            new InvalidArgumentException('Parameter does not contain a valid SemVer (sub)string.'),
+            UnrecognisableTestFrameworkVersion::create('PhpSpec', 'alpha.1'),
         ];
 
         yield [
             'alpha+beta',
-            new InvalidArgumentException('Parameter does not contain a valid SemVer (sub)string.'),
+            UnrecognisableTestFrameworkVersion::create('PhpSpec', 'alpha+beta'),
         ];
 
         yield [
             'alpha_beta',
-            new InvalidArgumentException('Parameter does not contain a valid SemVer (sub)string.'),
+            UnrecognisableTestFrameworkVersion::create('PhpSpec', 'alpha_beta'),
         ];
 
         yield [
             'alpha.',
-            new InvalidArgumentException('Parameter does not contain a valid SemVer (sub)string.'),
+            UnrecognisableTestFrameworkVersion::create('PhpSpec', 'alpha.'),
         ];
 
         yield [
             'alpha..',
-            new InvalidArgumentException('Parameter does not contain a valid SemVer (sub)string.'),
+            UnrecognisableTestFrameworkVersion::create('PhpSpec', 'alpha..'),
         ];
 
         yield [
             'beta',
-            new InvalidArgumentException('Parameter does not contain a valid SemVer (sub)string.'),
+            UnrecognisableTestFrameworkVersion::create('PhpSpec', 'beta'),
         ];
 
         yield ['1.0.0-alpha_beta', '1.0.0-alpha'];    // TODO: this is incorrect
 
         yield [
             '-alpha.',
-            new InvalidArgumentException('Parameter does not contain a valid SemVer (sub)string.'),
+            UnrecognisableTestFrameworkVersion::create('PhpSpec', '-alpha.'),
         ];
 
         yield '1.0.0-alpha..';
@@ -298,7 +298,7 @@ final class VersionParserTest extends TestCase
 
         yield [
             '+justmeta',
-            new InvalidArgumentException('Parameter does not contain a valid SemVer (sub)string.'),
+            UnrecognisableTestFrameworkVersion::create('PhpSpec', '+justmeta'),
         ];
 
         yield ['9.8.7+meta+meta', '9.8.7+meta'];  // TODO: this is incorrect
@@ -330,7 +330,7 @@ final class VersionParserTest extends TestCase
 
         yield [
             'dev-main',
-            new InvalidArgumentException('Parameter does not contain a valid SemVer (sub)string.'),
+            UnrecognisableTestFrameworkVersion::create('PhpSpec', 'dev-main'),
         ];    // TODO: this is incorrect
     }
 }


### PR DESCRIPTION
The rationale being:

- One could react on it (e.g. to use a fallback value or use a different
  way to get the version).
- As such, it is more suited as a `RuntimeException` rather than a
  `LogicException`.
- Provide a more user-friendly error message.

I also think this should eventually be extracted to `infection/abstract-testframework-adapter` (see https://github.com/infection/infection/issues/2760).