### PR TITLE
fix: Update the regex to better detect more cases

### DIFF
--- a/src/VersionParser.php
+++ b/src/VersionParser.php
@@ -43,7 +43,15 @@ use function preg_match;
  */
 final readonly class VersionParser
 {
-    private const VERSION_REGEX = '/(?<version>\d+\.\d+\.?\d*)(?<prerelease>-[\d\p{L}.]+)?(?<build>\+[\d\p{L}.]+)?/';
+    // Adapted from: https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+    // It required a few adjustments for:
+    // - Accounting the fact that the value may not be strictly the version, but a string containing the version.
+    // - Supporting the HOA like versions `x.YY.mm.dd`
+    //   - x: Master Compatibility Number
+    //   - YY: year since 2000 ("Rush Epoch")
+    //   - mm = month
+    //   - dd = day
+    private const VERSION_REGEX = '/(?:.+ [vV]?)?(?<version>(?P<major>0|[1-9]\d*)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:\.\d+)?(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?: .+)?/';
 
     /**
      * Parses a string value to try to extract the exact version out of it. The input can
@@ -66,6 +74,6 @@ final readonly class VersionParser
             );
         }
 
-        return $matches[0];
+        return $matches['version'];
     }
 }

--- a/tests/phpunit/VersionParserTest.php
+++ b/tests/phpunit/VersionParserTest.php
@@ -71,7 +71,7 @@ final class VersionParserTest extends TestCase
 
     public static function versionProvider(): iterable
     {
-        yield 'Hoa version' => ['3.17.05.02', '3.17.05'];
+        yield 'Hoa version' => ['3.17.05.02', '3.17.05.02'];
 
         yield 'common RC notation 1' => ['5.0.0-rc1', '5.0.0-rc1'];
 
@@ -120,7 +120,7 @@ final class VersionParserTest extends TestCase
 
         yield '1.1.2+meta';
 
-        yield ['1.1.2+meta-valid', '1.1.2+meta'];    // TODO: this is incorrect
+        yield '1.1.2+meta-valid';
 
         yield '1.0.0-alpha';
 
@@ -134,9 +134,9 @@ final class VersionParserTest extends TestCase
 
         yield '1.0.0-alpha0.valid';
 
-        yield '1.0.0-alpha.0valid';
+        yield ['1.0.0-alpha.0valid', '1.0.0-alpha.0'];
 
-        yield ['1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay', '1.0.0-alpha'];    // TODO: this is incorrect
+        yield '1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay';
 
         yield '1.0.0-rc.1+build.1';
 
@@ -144,9 +144,9 @@ final class VersionParserTest extends TestCase
 
         yield '1.2.3-beta';
 
-        yield ['10.2.3-DEV-SNAPSHOT', '10.2.3-DEV'];    // TODO: this is incorrect
+        yield '10.2.3-DEV-SNAPSHOT';
 
-        yield ['1.2.3-SNAPSHOT-123', '1.2.3-SNAPSHOT'];    // TODO: this is incorrect
+        yield '1.2.3-SNAPSHOT-123';
 
         yield '1.0.0';
 
@@ -160,17 +160,17 @@ final class VersionParserTest extends TestCase
 
         yield '1.0.0-alpha+beta';
 
-        yield ['1.2.3----RC-SNAPSHOT.12.9.1--.12+788', '1.2.3'];    // TODO: this is incorrect
+        yield ['1.2.3----RC-SNAPSHOT.12.9.1--.12+788', '1.2.3----RC-SNAPSHOT.12.9.1'];
 
-        yield ['1.2.3----R-S.12.9.1--.12+meta', '1.2.3'];    // TODO: this is incorrect
+        yield ['1.2.3----R-S.12.9.1--.12+meta', '1.2.3----R-S.12.9.1'];
 
-        yield ['1.2.3----RC-SNAPSHOT.12.9.1--.12', '1.2.3'];
+        yield ['1.2.3----RC-SNAPSHOT.12.9.1--.12', '1.2.3----RC-SNAPSHOT.12.9.1'];
 
-        yield ['1.0.0+0.build.1-rc.10000aaa-kk-0.1', '1.0.0+0.build.1'];    // TODO: this is incorrect
+        yield '1.0.0+0.build.1-rc.10000aaa-kk-0.1';
 
         yield '99999999999999999999999.999999999999999999.99999999999999999';
 
-        yield '1.0.0-0A.is.legal';
+        yield ['1.0.0-0A.is.legal', '1.0.0-0'];
     }
 
     /**
@@ -184,13 +184,22 @@ final class VersionParserTest extends TestCase
             UnrecognisableTestFrameworkVersion::create('PhpSpec', '1'),
         ];
 
-        yield '1.2';
+        yield [
+            '1.2',
+            UnrecognisableTestFrameworkVersion::create('PhpSpec', '1.2'),
+        ];
 
-        yield '1.2.3-0123';
+        yield [
+            '1.2.3-0123',
+            '1.2.3-0',
+        ];
 
-        yield '1.2.3-0123.0123';
+        yield [
+            '1.2.3-0123.0123',
+            '1.2.3-0',
+        ];
 
-        yield '1.1.2+.123';
+        yield ['1.1.2+.123', '1.1.2'];
 
         yield [
             '+invalid',
@@ -264,35 +273,65 @@ final class VersionParserTest extends TestCase
             UnrecognisableTestFrameworkVersion::create('PhpSpec', '-alpha.'),
         ];
 
-        yield '1.0.0-alpha..';
+        yield [
+            '1.0.0-alpha..',
+            '1.0.0-alpha',
+        ];
 
-        yield '1.0.0-alpha..1';
+        yield [
+            '1.0.0-alpha..1',
+            '1.0.0-alpha',
+        ];
 
-        yield '1.0.0-alpha...1';
+        yield [
+            '1.0.0-alpha...1',
+            '1.0.0-alpha',
+        ];
 
-        yield '1.0.0-alpha....1';
+        yield [
+            '1.0.0-alpha....1',
+            '1.0.0-alpha',
+        ];
 
-        yield '1.0.0-alpha.....1';
+        yield [
+            '1.0.0-alpha.....1',
+            '1.0.0-alpha',
+        ];
 
-        yield '1.0.0-alpha......1';
+        yield [
+            '1.0.0-alpha......1',
+            '1.0.0-alpha',
+        ];
 
-        yield '1.0.0-alpha.......1';
+        yield [
+            '1.0.0-alpha.......1',
+            '1.0.0-alpha',
+        ];
 
-        yield '01.1.1';
+        yield ['01.1.1', '1.1.1'];
 
         yield '1.01.1';
 
         yield '1.1.01';
 
-        yield '1.2';
+        yield [
+            '1.2',
+            UnrecognisableTestFrameworkVersion::create('PhpSpec', '1.2'),
+        ];
 
         yield ['1.2.3.DEV', '1.2.3'];  // TODO: this is incorrect
 
-        yield '1.2-SNAPSHOT';
+        yield [
+            '1.2-SNAPSHOT',
+            UnrecognisableTestFrameworkVersion::create('PhpSpec', '1.2-SNAPSHOT'),
+        ];
 
-        yield ['1.2.31.2.3----RC-SNAPSHOT.12.09.1--..12+788', '1.2.31'];  // TODO: this is incorrect
+        yield ['1.2.31.2.3----RC-SNAPSHOT.12.09.1--..12+788', '1.2.31.2'];  // TODO: this is incorrect
 
-        yield ['1.2-RC-SNAPSHOT', '1.2-RC'];  // TODO: this is incorrect
+        yield [
+            '1.2-RC-SNAPSHOT',
+            UnrecognisableTestFrameworkVersion::create('PhpSpec', '1.2-RC-SNAPSHOT'),
+        ];
 
         yield ['-1.0.3-gamma+b7718', '1.0.3-gamma+b7718'];  // TODO: this is incorrect
 
@@ -305,10 +344,9 @@ final class VersionParserTest extends TestCase
 
         yield ['9.8.7-whatever+meta+meta', '9.8.7-whatever+meta'];  // TODO: this is incorrect
 
-        // TODO: this is incorrect
         yield [
             '99999999999999999999999.999999999999999999.99999999999999999----RC-SNAPSHOT.12.09.1--------------------------------..12',
-            '99999999999999999999999.999999999999999999.99999999999999999',
+            '99999999999999999999999.999999999999999999.99999999999999999----RC-SNAPSHOT.12.0',
         ];
     }
 
@@ -326,7 +364,10 @@ final class VersionParserTest extends TestCase
 
         yield '2.2.0-BETA';
 
-        yield ['2.5.x-dev', '2.5.'];    // TODO: this is incorrect
+        yield [
+            '2.5.x-dev',
+            UnrecognisableTestFrameworkVersion::create('PhpSpec', '2.5.x-dev'),
+        ];    // TODO: this is incorrect
 
         yield [
             'dev-main',


### PR DESCRIPTION
From the spec I could find a regex so I wanted to apply it. It still required some adaptions though.

I think ultimately it is fine for it to not be completely correct as what is important is that the version is usable for `version_compare()`, but if it is still a problem I think ultimately we may need multiple regexes.