### PR TITLE
refactor: Rename PhpSpecConfigurationBuilder methods

### DIFF
--- a/src/Config/Builder/InitialConfigBuilder.php
+++ b/src/Config/Builder/InitialConfigBuilder.php
@@ -63,7 +63,7 @@ class InitialConfigBuilder
         if ($this->skipCoverage) {
             $configuration->removeCoverageExtension();
         } else {
-            $configuration->updateCodeCoveragePath();
+            $configuration->configureXmlCoverageReportIfNecessary();
         }
 
         file_put_contents($path, $configuration->getYaml());

--- a/src/Config/Builder/MutationConfigBuilder.php
+++ b/src/Config/Builder/MutationConfigBuilder.php
@@ -84,7 +84,7 @@ class MutationConfigBuilder
             $this->tempDirectory,
             $parsedYaml,
         );
-        $configuration->setCustomAutoLoaderPath($customAutoloadFilePath);
+        $configuration->setBootstrap($customAutoloadFilePath);
         $configuration->removeCoverageExtension();
 
         $newYaml = $configuration->getYaml();

--- a/src/Config/PhpSpecConfigurationBuilder.php
+++ b/src/Config/PhpSpecConfigurationBuilder.php
@@ -66,7 +66,7 @@ final class PhpSpecConfigurationBuilder
     /**
      * @throws NoCodeCoverageException
      */
-    public function updateCodeCoveragePath(): void
+    public function configureXmlCoverageReportIfNecessary(): void
     {
         $this->assertHasCoverageExtension();
 
@@ -86,7 +86,7 @@ final class PhpSpecConfigurationBuilder
     /**
      * @param non-empty-string $mutantAutoloadPathname
      */
-    public function setCustomAutoLoaderPath(string $mutantAutoloadPathname): void
+    public function setBootstrap(string $mutantAutoloadPathname): void
     {
         // bootstrap must be before other keys because of PhpSpec bug with populating container under
         // some circumstances

--- a/tests/phpunit/Config/PhpSpecConfigurationBuilderTest.php
+++ b/tests/phpunit/Config/PhpSpecConfigurationBuilderTest.php
@@ -212,7 +212,7 @@ final class PhpSpecConfigurationBuilderTest extends TestCase
             $this->expectException($expected);
         }
 
-        $builder->updateCodeCoveragePath();
+        $builder->configureXmlCoverageReportIfNecessary();
 
         if (!$expectsException) {
             $actual = $builder->getYaml();
@@ -370,7 +370,7 @@ final class PhpSpecConfigurationBuilderTest extends TestCase
             Yaml::parse($original) ?? [],
         );
 
-        $builder->setCustomAutoLoaderPath($bootstrap);
+        $builder->setBootstrap($bootstrap);
 
         $actual = $builder->getYaml();
 


### PR DESCRIPTION
Renamed:

| before | after |
|--|--|
| updateCodeCoveragePath | configureXmlCoverageReportIfNecessary |
| setCustomAutoLoaderPath | setBootstrap |

`updateCodeCoveragePath` didn't really convey that we're configuring the XML coverage report for infection, and that it is done only if necessary.

`setCustomAutoLoaderPath` is technically correct, but the terminology employed by PhpSpec in their configuration file is `bootstrap`.