### PR TITLE
feat: Fail gracefully when an invalid configuration is provided

### DIFF
--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -11,3 +11,15 @@ parameters:
     inferPrivatePropertyTypeFromConstructor: true
     ignoreErrors:
         - '#Dynamic call to static method PHPUnit\\Framework\\.*::.*#'
+
+        # ::configureXmlCoverageReportIfNecessary() false-positives
+        # This is happening because `::assertHasCoverageExtension()` cannot easily narrow down the
+        # parsedYaml type...
+        -
+            message: '#Argument of an invalid type array<string, mixed>\|null supplied for foreach, only iterables are supported\.#'
+            path: src/Config/PhpSpecConfigurationBuilder.php
+            identifier: foreach.nonIterable
+        -
+            message: "#Offset 'extensions' might not exist on array\\{extensions\\?: array<string, mixed>\\|null\\}\\.#"
+            path: src/Config/PhpSpecConfigurationBuilder.php
+            identifier: offsetAccess.notFound

--- a/src/Config/PhpSpecConfigurationBuilder.php
+++ b/src/Config/PhpSpecConfigurationBuilder.php
@@ -123,13 +123,12 @@ final class PhpSpecConfigurationBuilder
     private static function assertIsSupportedExtensionsFormat(array $parsedYaml): void
     {
         if (!array_key_exists('extensions', $parsedYaml)
-        || $parsedYaml['extensions'] === null
+            || $parsedYaml['extensions'] === null
         ) {
             return;
         }
 
-        if (
-            !is_array($parsedYaml['extensions'])
+        if (!is_array($parsedYaml['extensions'])
             || array_is_list($parsedYaml['extensions'])
         ) {
             throw UnrecognisableConfiguration::fromInvalidExtensionsType();

--- a/src/Config/PhpSpecConfigurationBuilder.php
+++ b/src/Config/PhpSpecConfigurationBuilder.php
@@ -35,8 +35,11 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework\PhpSpec\Config;
 
+use function array_is_list;
 use function array_key_exists;
 use Infection\TestFramework\PhpSpec\PhpSpecAdapter;
+use Infection\TestFramework\PhpSpec\Throwable\UnrecognisableConfiguration;
+use function is_array;
 use function str_contains;
 use Symfony\Component\Yaml\Yaml;
 
@@ -46,12 +49,26 @@ use Symfony\Component\Yaml\Yaml;
 final class PhpSpecConfigurationBuilder
 {
     /**
-     * @param array<string, mixed> $parsedYaml
+     * @param array{extensions?: array<string, mixed>|null}&array<string, mixed> $parsedYaml
      */
     public function __construct(
         private readonly string $tmpDirectory,
         private array $parsedYaml,
     ) {
+    }
+
+    /**
+     * @param array<string, mixed> $parsedYaml
+     *
+     * @throws UnrecognisableConfiguration
+     */
+    public static function create(
+        string $tmpDirectory,
+        array $parsedYaml,
+    ): self {
+        self::assertIsSupportedExtensionsFormat($parsedYaml);
+
+        return new self($tmpDirectory, $parsedYaml);
     }
 
     public function removeCoverageExtension(): void
@@ -96,6 +113,27 @@ final class PhpSpecConfigurationBuilder
     public function getYaml(): string
     {
         return Yaml::dump($this->parsedYaml);
+    }
+
+    /**
+     * @param array<string, mixed> $parsedYaml
+     *
+     * @phpstan-assert array{extensions?: null|array<string, mixed>}&array<string, mixed> $parsedYaml
+     */
+    private static function assertIsSupportedExtensionsFormat(array $parsedYaml): void
+    {
+        if (!array_key_exists('extensions', $parsedYaml)
+        || $parsedYaml['extensions'] === null
+        ) {
+            return;
+        }
+
+        if (
+            !is_array($parsedYaml['extensions'])
+            || array_is_list($parsedYaml['extensions'])
+        ) {
+            throw UnrecognisableConfiguration::fromInvalidExtensionsType();
+        }
     }
 
     /**

--- a/src/PhpSpecAdapter.php
+++ b/src/PhpSpecAdapter.php
@@ -169,6 +169,7 @@ final class PhpSpecAdapter implements TestFrameworkAdapter
             $mutantFilePath,
             $mutationHash,
             $mutationOriginalFilePath,
+            $this->getVersion(),
         );
     }
 

--- a/tests/phpunit/Throwable/UnrecognisableConfigurationTest.php
+++ b/tests/phpunit/Throwable/UnrecognisableConfigurationTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\TestFramework\PhpSpec\Throwable;
+
+use Exception;
+use Infection\TestFramework\PhpSpec\Throwable\UnrecognisableConfiguration;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Throwable;
+
+#[CoversClass(UnrecognisableConfiguration::class)]
+final class UnrecognisableConfigurationTest extends TestCase
+{
+    public function test_it_can_enrich_an_existing_instance_with_the_version(): void
+    {
+        $original = new UnrecognisableConfiguration(
+            'Original message.',
+            10,
+        );
+
+        $newException = $original->enrichWithVersion('2.0.0');
+
+        $this->assertExceptionStateIs(
+            $original,
+            'Original message.',
+            10,
+            null,
+        );
+        $this->assertExceptionStateIs(
+            $newException,
+            'Could not recognise the current configuration format for the version "2.0.0": Original message.',
+            10,
+            $original,
+        );
+    }
+
+    private function assertExceptionStateIs(
+        Exception $exception,
+        string $expectedMessage,
+        int $expectedCode,
+        ?Throwable $expectedPrevious,
+    ): void {
+        $this->assertSame($expectedMessage, $exception->getMessage());
+        $this->assertSame($expectedCode, $exception->getCode());
+        $this->assertSame($expectedPrevious, $exception->getPrevious());
+    }
+}


### PR DESCRIPTION
In #61 I fixed various cases related to the usage of the legacy configuration. Turns out it's not allowed anymore since 2016 so why bother.

Instead this PR adds the checks to ensure it is the case and fail gracefully when it is not.