### PR TITLE
perf: Do not fetch the content of the original configuration more than once

### DIFF
--- a/src/Config/Builder/InitialConfigBuilder.php
+++ b/src/Config/Builder/InitialConfigBuilder.php
@@ -47,7 +47,7 @@ class InitialConfigBuilder
 {
     public function __construct(
         private readonly string $tempDirectory,
-        private readonly string $originalYamlConfigPath,
+        private readonly string $originalPhpSpecConfigContents,
         private readonly bool $skipCoverage,
     ) {
     }
@@ -59,7 +59,7 @@ class InitialConfigBuilder
         try {
             $configuration = PhpSpecConfigurationBuilder::create(
                 $this->tempDirectory,
-                Yaml::parseFile($this->originalYamlConfigPath),
+                Yaml::parse($this->originalPhpSpecConfigContents),
             );
         } catch (UnrecognisableConfiguration $exception) {
             throw $exception->enrichWithVersion($version);

--- a/src/Config/Builder/MutationConfigBuilder.php
+++ b/src/Config/Builder/MutationConfigBuilder.php
@@ -57,7 +57,7 @@ class MutationConfigBuilder
 {
     public function __construct(
         private readonly string $tempDirectory,
-        private readonly string $originalYamlConfigPath,
+        private readonly string $originalPhpSpecConfigContents,
         private readonly string $projectDir,
     ) {
     }
@@ -78,7 +78,7 @@ class MutationConfigBuilder
             $mutationHash,
         );
 
-        $parsedYaml = Yaml::parseFile($this->originalYamlConfigPath);
+        $parsedYaml = Yaml::parse($this->originalPhpSpecConfigContents);
 
         file_put_contents($customAutoloadFilePath, $this->createCustomAutoloadWithInterceptor($mutationOriginalFilePath, $mutantFilePath, $parsedYaml));
 

--- a/src/PhpSpecAdapterFactory.php
+++ b/src/PhpSpecAdapterFactory.php
@@ -40,6 +40,7 @@ use Infection\AbstractTestFramework\TestFrameworkAdapterFactory;
 use Infection\TestFramework\PhpSpec\CommandLine\ArgumentsAndOptionsBuilder;
 use Infection\TestFramework\PhpSpec\Config\Builder\InitialConfigBuilder;
 use Infection\TestFramework\PhpSpec\Config\Builder\MutationConfigBuilder;
+use Symfony\Component\Filesystem\Filesystem;
 
 final class PhpSpecAdapterFactory implements TestFrameworkAdapterFactory
 {
@@ -56,10 +57,13 @@ final class PhpSpecAdapterFactory implements TestFrameworkAdapterFactory
         array $sourceDirectories,
         bool $skipCoverage,
     ): TestFrameworkAdapter {
+        $filesystem = new Filesystem();
+        $phpSpecConfigContents = $filesystem->readFile($testFrameworkConfigPath);
+
         return new PhpSpecAdapter(
             $testFrameworkExecutable,
-            new InitialConfigBuilder($tmpDir, $testFrameworkConfigPath, $skipCoverage),
-            new MutationConfigBuilder($tmpDir, $testFrameworkConfigPath, $projectDir),
+            new InitialConfigBuilder($tmpDir, $phpSpecConfigContents, $skipCoverage),
+            new MutationConfigBuilder($tmpDir, $phpSpecConfigContents, $projectDir),
             new ArgumentsAndOptionsBuilder(),
             new VersionParser(),
             new CommandLineBuilder(),

--- a/tests/phpunit/Config/Builder/InitialConfigBuilderTest.php
+++ b/tests/phpunit/Config/Builder/InitialConfigBuilderTest.php
@@ -40,7 +40,7 @@ use Infection\TestFramework\PhpSpec\Throwable\UnrecognisableConfiguration;
 use Infection\Tests\TestFramework\PhpSpec\FileSystem\FileSystemTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
-use function Safe\file_put_contents;
+use function Safe\file_get_contents;
 
 #[Group('integration')]
 #[CoversClass(InitialConfigBuilder::class)]
@@ -48,9 +48,9 @@ final class InitialConfigBuilderTest extends FileSystemTestCase
 {
     public function test_it_builds_path_to_initial_config_file(): void
     {
-        $originalYamlConfigPath = __DIR__ . '/../../../Fixtures/Files/phpspec/phpspec.yml';
+        $originalPhpSpecConfigContents = file_get_contents(__DIR__ . '/../../../Fixtures/Files/phpspec/phpspec.yml');
 
-        $builder = new InitialConfigBuilder($this->tmp, $originalYamlConfigPath, false);
+        $builder = new InitialConfigBuilder($this->tmp, $originalPhpSpecConfigContents, false);
 
         $actualPath = $builder->build('2.0');
 
@@ -60,22 +60,18 @@ final class InitialConfigBuilderTest extends FileSystemTestCase
 
     public function test_it_provides_a_friendly_error_if_the_configuration_is_invalud(): void
     {
-        $originalYamlConfigPath = $this->tmp . '/phpspec.yml';
-        file_put_contents(
-            $originalYamlConfigPath,
-            <<<'YAML'
-                suites: ~
-                extensions:
-                    - Acme\Extension\FirstExampleExtension
-                    - Acme\Extension\CodeCoverageExtension
-                    - Acme\Extension\SecondExampleExtension
+        $originalPhpSpecConfigContents = <<<'YAML'
+            suites: ~
+            extensions:
+                - Acme\Extension\FirstExampleExtension
+                - Acme\Extension\CodeCoverageExtension
+                - Acme\Extension\SecondExampleExtension
 
-                YAML,
-        );
+            YAML;
 
         $builder = new InitialConfigBuilder(
             $this->tmp,
-            $originalYamlConfigPath,
+            $originalPhpSpecConfigContents,
             false,
         );
 

--- a/tests/phpunit/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/phpunit/Config/Builder/MutationConfigBuilderTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\TestFramework\PhpSpec\Config\Builder;
 
-use function file_put_contents;
 use Infection\TestFramework\PhpSpec\Config\Builder\MutationConfigBuilder;
 use Infection\TestFramework\PhpSpec\Throwable\UnrecognisableConfiguration;
 use Infection\Tests\TestFramework\PhpSpec\FileSystem\FileSystemTestCase;
@@ -56,9 +55,9 @@ final class MutationConfigBuilderTest extends FileSystemTestCase
     public function test_it_builds_path_to_mutation_config_file(): void
     {
         $projectDir = '/project/dir';
-        $originalYamlConfigPath = __DIR__ . '/../../../Fixtures/Files/phpspec/phpspec.yml';
+        $originalPhpSpecConfigContents = file_get_contents(__DIR__ . '/../../../Fixtures/Files/phpspec/phpspec.yml');
 
-        $builder = new MutationConfigBuilder($this->tmp, $originalYamlConfigPath, $projectDir);
+        $builder = new MutationConfigBuilder($this->tmp, $originalPhpSpecConfigContents, $projectDir);
 
         $actualPath = $builder->build(
             [],
@@ -75,9 +74,9 @@ final class MutationConfigBuilderTest extends FileSystemTestCase
     public function test_it_adds_original_bootstrap_file_to_custom_autoload(): void
     {
         $projectDir = '/project/dir';
-        $originalYamlConfigPath = __DIR__ . '/../../../Fixtures/Files/phpspec/phpspec.with.bootstrap.yml';
+        $originalPhpSpecConfigContents = file_get_contents(__DIR__ . '/../../../Fixtures/Files/phpspec/phpspec.with.bootstrap.yml');
 
-        $builder = new MutationConfigBuilder($this->tmp, $originalYamlConfigPath, $projectDir);
+        $builder = new MutationConfigBuilder($this->tmp, $originalPhpSpecConfigContents, $projectDir);
 
         $this->assertSame(
             $this->tmp . '/phpspecConfiguration.a1b2c3.infection.yml',
@@ -99,9 +98,9 @@ final class MutationConfigBuilderTest extends FileSystemTestCase
     public function test_interceptor_is_included(): void
     {
         $projectDir = '/project/dir';
-        $originalYamlConfigPath = __DIR__ . '/../../../Fixtures/Files/phpspec/phpspec.yml';
+        $originalPhpSpecConfigContents = file_get_contents(__DIR__ . '/../../../Fixtures/Files/phpspec/phpspec.yml');
 
-        $builder = new MutationConfigBuilder($this->tmp, $originalYamlConfigPath, $projectDir);
+        $builder = new MutationConfigBuilder($this->tmp, $originalPhpSpecConfigContents, $projectDir);
 
         $this->assertSame(
             $this->tmp . '/phpspecConfiguration.a1b2c3.infection.yml',
@@ -122,22 +121,18 @@ final class MutationConfigBuilderTest extends FileSystemTestCase
 
     public function test_it_provides_a_friendly_error_if_the_configuration_is_invalud(): void
     {
-        $originalYamlConfigPath = $this->tmp . '/phpspec.yml';
-        file_put_contents(
-            $originalYamlConfigPath,
-            <<<'YAML'
-                suites: ~
-                extensions:
-                    - Acme\Extension\FirstExampleExtension
-                    - Acme\Extension\CodeCoverageExtension
-                    - Acme\Extension\SecondExampleExtension
+        $originalPhpSpecConfigContents = <<<'YAML'
+            suites: ~
+            extensions:
+                - Acme\Extension\FirstExampleExtension
+                - Acme\Extension\CodeCoverageExtension
+                - Acme\Extension\SecondExampleExtension
 
-                YAML,
-        );
+            YAML;
 
         $builder = new MutationConfigBuilder(
             $this->tmp,
-            $originalYamlConfigPath,
+            $originalPhpSpecConfigContents,
             '/path/to/project',
         );
 

--- a/tests/phpunit/PhpSpecAdapterFactoryTest.php
+++ b/tests/phpunit/PhpSpecAdapterFactoryTest.php
@@ -50,7 +50,7 @@ final class PhpSpecAdapterFactoryTest extends TestCase
         $adapter = PhpSpecAdapterFactory::create(
             '/path/to/phpspec',
             '/tmp',
-            __DIR__ . '/../../../Fixtures/Files/phpspec/phpspec.yml',
+            __DIR__ . '/../Fixtures/Files/phpspec/phpspec.yml',
             null,
             '/path/to/junit.xml',
             '/path/to/project',


### PR DESCRIPTION
We've been using `Yaml::parseFile` in `InitialConfigBuilder` and `MutationConfigBuilder`.

I think one reason for it, is that the PhpSpec configuration builder itself is mutable, so we get a fresh instance in each and there is no risk of corrupting the data of another mutation. However, in its current form, this means we not only do the parsing of the YAML everytime, but also fetching the file from the filesystem, which is easily preventable.

In this PR, we fetch the content of the PhpSpec configuration file (not decoded) when building the adapter instance. As a result, we can forward that data, reducing the filesystem calls from `initial + nbrOfMutation` to 1.
