### PR TITLE
perf: Decode the YAML of the original PhpSpec configuration only once

### DIFF
--- a/src/Config/Builder/InitialConfigBuilder.php
+++ b/src/Config/Builder/InitialConfigBuilder.php
@@ -38,16 +38,20 @@ namespace Infection\TestFramework\PhpSpec\Config\Builder;
 use function file_put_contents;
 use Infection\TestFramework\PhpSpec\Config\PhpSpecConfigurationBuilder;
 use Infection\TestFramework\PhpSpec\Throwable\UnrecognisableConfiguration;
-use Symfony\Component\Yaml\Yaml;
 
 /**
+ * @phpstan-import-type DecodedPhpSpecConfig from PhpSpecConfigurationBuilder
+ *
  * @internal
  */
 class InitialConfigBuilder
 {
+    /**
+     * @param DecodedPhpSpecConfig $originalPhpSpecConfigDecodedContents
+     */
     public function __construct(
         private readonly string $tempDirectory,
-        private readonly string $originalPhpSpecConfigContents,
+        private readonly array $originalPhpSpecConfigDecodedContents,
         private readonly bool $skipCoverage,
     ) {
     }
@@ -59,7 +63,7 @@ class InitialConfigBuilder
         try {
             $configuration = PhpSpecConfigurationBuilder::create(
                 $this->tempDirectory,
-                Yaml::parse($this->originalPhpSpecConfigContents),
+                $this->originalPhpSpecConfigDecodedContents,
             );
         } catch (UnrecognisableConfiguration $exception) {
             throw $exception->enrichWithVersion($version);

--- a/src/Config/PhpSpecConfigurationBuilder.php
+++ b/src/Config/PhpSpecConfigurationBuilder.php
@@ -44,12 +44,14 @@ use function str_contains;
 use Symfony\Component\Yaml\Yaml;
 
 /**
+ * @phpstan-type DecodedPhpSpecConfig = array{extensions?: array<string, mixed>|null}&mixed[]
+ *
  * @internal
  */
 final class PhpSpecConfigurationBuilder
 {
     /**
-     * @param array{extensions?: array<string, mixed>|null}&array<string, mixed> $parsedYaml
+     * @param DecodedPhpSpecConfig $parsedYaml
      */
     public function __construct(
         private readonly string $tmpDirectory,
@@ -58,7 +60,7 @@ final class PhpSpecConfigurationBuilder
     }
 
     /**
-     * @param array<string, mixed> $parsedYaml
+     * @param mixed[] $parsedYaml
      *
      * @throws UnrecognisableConfiguration
      */
@@ -120,7 +122,7 @@ final class PhpSpecConfigurationBuilder
     /**
      * @param array<string, mixed> $parsedYaml
      *
-     * @phpstan-assert array{extensions?: null|array<string, mixed>}&array<string, mixed> $parsedYaml
+     * @phpstan-assert DecodedPhpSpecConfig $parsedYaml
      */
     private static function assertIsSupportedExtensionsFormat(array $parsedYaml): void
     {

--- a/src/PhpSpecAdapterFactory.php
+++ b/src/PhpSpecAdapterFactory.php
@@ -45,6 +45,7 @@ use InvalidArgumentException;
 use function method_exists;
 use function sprintf;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Yaml\Yaml;
 
 final class PhpSpecAdapterFactory implements TestFrameworkAdapterFactory
 {
@@ -78,10 +79,12 @@ final class PhpSpecAdapterFactory implements TestFrameworkAdapterFactory
             );
         }
 
+        $phpSpecConfigDecodedContents = Yaml::parse($phpSpecConfigContents);
+
         return new PhpSpecAdapter(
             $testFrameworkExecutable,
-            new InitialConfigBuilder($tmpDir, $phpSpecConfigContents, $skipCoverage),
-            new MutationConfigBuilder($tmpDir, $phpSpecConfigContents, $projectDir),
+            new InitialConfigBuilder($tmpDir, $phpSpecConfigDecodedContents, $skipCoverage),
+            new MutationConfigBuilder($tmpDir, $phpSpecConfigDecodedContents, $projectDir),
             new ArgumentsAndOptionsBuilder(),
             new VersionParser(),
             new CommandLineBuilder(),

--- a/tests/phpunit/Config/Builder/InitialConfigBuilderTest.php
+++ b/tests/phpunit/Config/Builder/InitialConfigBuilderTest.php
@@ -40,7 +40,7 @@ use Infection\TestFramework\PhpSpec\Throwable\UnrecognisableConfiguration;
 use Infection\Tests\TestFramework\PhpSpec\FileSystem\FileSystemTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
-use function Safe\file_get_contents;
+use Symfony\Component\Yaml\Yaml;
 
 #[Group('integration')]
 #[CoversClass(InitialConfigBuilder::class)]
@@ -48,9 +48,9 @@ final class InitialConfigBuilderTest extends FileSystemTestCase
 {
     public function test_it_builds_path_to_initial_config_file(): void
     {
-        $originalPhpSpecConfigContents = file_get_contents(__DIR__ . '/../../../Fixtures/Files/phpspec/phpspec.yml');
+        $originalPhpSpecConfigDecodedContents = Yaml::parseFile(__DIR__ . '/../../../Fixtures/Files/phpspec/phpspec.yml');
 
-        $builder = new InitialConfigBuilder($this->tmp, $originalPhpSpecConfigContents, false);
+        $builder = new InitialConfigBuilder($this->tmp, $originalPhpSpecConfigDecodedContents, false);
 
         $actualPath = $builder->build('2.0');
 
@@ -60,18 +60,20 @@ final class InitialConfigBuilderTest extends FileSystemTestCase
 
     public function test_it_provides_a_friendly_error_if_the_configuration_is_invalud(): void
     {
-        $originalPhpSpecConfigContents = <<<'YAML'
-            suites: ~
-            extensions:
-                - Acme\Extension\FirstExampleExtension
-                - Acme\Extension\CodeCoverageExtension
-                - Acme\Extension\SecondExampleExtension
+        $originalPhpSpecConfigDecodedContents = Yaml::parse(
+            <<<'YAML'
+                suites: ~
+                extensions:
+                    - Acme\Extension\FirstExampleExtension
+                    - Acme\Extension\CodeCoverageExtension
+                    - Acme\Extension\SecondExampleExtension
 
-            YAML;
+                YAML,
+        );
 
         $builder = new InitialConfigBuilder(
             $this->tmp,
-            $originalPhpSpecConfigContents,
+            $originalPhpSpecConfigDecodedContents,
             false,
         );
 

--- a/tests/phpunit/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/phpunit/Config/Builder/MutationConfigBuilderTest.php
@@ -41,6 +41,7 @@ use Infection\Tests\TestFramework\PhpSpec\FileSystem\FileSystemTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use function Safe\file_get_contents;
+use Symfony\Component\Yaml\Yaml;
 
 #[Group('integration')]
 #[CoversClass(MutationConfigBuilder::class)]
@@ -55,9 +56,9 @@ final class MutationConfigBuilderTest extends FileSystemTestCase
     public function test_it_builds_path_to_mutation_config_file(): void
     {
         $projectDir = '/project/dir';
-        $originalPhpSpecConfigContents = file_get_contents(__DIR__ . '/../../../Fixtures/Files/phpspec/phpspec.yml');
+        $originalPhpSpecConfigDecodedContents = Yaml::parseFile(__DIR__ . '/../../../Fixtures/Files/phpspec/phpspec.yml');
 
-        $builder = new MutationConfigBuilder($this->tmp, $originalPhpSpecConfigContents, $projectDir);
+        $builder = new MutationConfigBuilder($this->tmp, $originalPhpSpecConfigDecodedContents, $projectDir);
 
         $actualPath = $builder->build(
             [],
@@ -74,9 +75,9 @@ final class MutationConfigBuilderTest extends FileSystemTestCase
     public function test_it_adds_original_bootstrap_file_to_custom_autoload(): void
     {
         $projectDir = '/project/dir';
-        $originalPhpSpecConfigContents = file_get_contents(__DIR__ . '/../../../Fixtures/Files/phpspec/phpspec.with.bootstrap.yml');
+        $originalPhpSpecConfigDecodedContents = Yaml::parseFile(__DIR__ . '/../../../Fixtures/Files/phpspec/phpspec.with.bootstrap.yml');
 
-        $builder = new MutationConfigBuilder($this->tmp, $originalPhpSpecConfigContents, $projectDir);
+        $builder = new MutationConfigBuilder($this->tmp, $originalPhpSpecConfigDecodedContents, $projectDir);
 
         $this->assertSame(
             $this->tmp . '/phpspecConfiguration.a1b2c3.infection.yml',
@@ -98,9 +99,9 @@ final class MutationConfigBuilderTest extends FileSystemTestCase
     public function test_interceptor_is_included(): void
     {
         $projectDir = '/project/dir';
-        $originalPhpSpecConfigContents = file_get_contents(__DIR__ . '/../../../Fixtures/Files/phpspec/phpspec.yml');
+        $originalPhpSpecConfigDecodedContents = Yaml::parseFile(__DIR__ . '/../../../Fixtures/Files/phpspec/phpspec.yml');
 
-        $builder = new MutationConfigBuilder($this->tmp, $originalPhpSpecConfigContents, $projectDir);
+        $builder = new MutationConfigBuilder($this->tmp, $originalPhpSpecConfigDecodedContents, $projectDir);
 
         $this->assertSame(
             $this->tmp . '/phpspecConfiguration.a1b2c3.infection.yml',
@@ -121,18 +122,20 @@ final class MutationConfigBuilderTest extends FileSystemTestCase
 
     public function test_it_provides_a_friendly_error_if_the_configuration_is_invalud(): void
     {
-        $originalPhpSpecConfigContents = <<<'YAML'
-            suites: ~
-            extensions:
-                - Acme\Extension\FirstExampleExtension
-                - Acme\Extension\CodeCoverageExtension
-                - Acme\Extension\SecondExampleExtension
+        $originalPhpSpecConfigDecodedContents = Yaml::parse(
+            <<<'YAML'
+                suites: ~
+                extensions:
+                    - Acme\Extension\FirstExampleExtension
+                    - Acme\Extension\CodeCoverageExtension
+                    - Acme\Extension\SecondExampleExtension
 
-            YAML;
+                YAML,
+        );
 
         $builder = new MutationConfigBuilder(
             $this->tmp,
-            $originalPhpSpecConfigContents,
+            $originalPhpSpecConfigDecodedContents,
             '/path/to/project',
         );
 

--- a/tests/phpunit/Config/PhpSpecConfigurationBuilderTest.php
+++ b/tests/phpunit/Config/PhpSpecConfigurationBuilderTest.php
@@ -678,11 +678,11 @@ final class PhpSpecConfigurationBuilderTest extends TestCase
         $builder1->setBootstrap('bootstrap.php');
         $builder1->removeCoverageExtension();
 
-        $result1 = $builder1->getYAML();
+        $result1 = $builder1->getYaml();
 
         $builder2->configureXmlCoverageReportIfNecessary();
 
-        $result2 = $builder2->getYAML();
+        $result2 = $builder2->getYaml();
 
         $this->assertSame(
             <<<'YAML'


### PR DESCRIPTION
Same line of thoughts as #68.