### PR TITLE
ci: Fix the update workflow

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get latest Infection release
         id: latest-release


### PR DESCRIPTION
When the checkout action receives a token, it configures git credentials that persist for subsequent steps, which causes issues for the `peter-evans/create-pull-request` action.

See:

```
Run peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f
Prepare git configuration
Determining the base and head repositories
Pull request branch target repository set to infection/phpspec-adapter
Configuring credential for HTTPS authentication
Checking the base repository state
  /usr/bin/git symbolic-ref HEAD --short
  main
  Working base is branch 'main'
  /usr/bin/git remote prune origin
  remote: Duplicate header: "Authorization"
  fatal: unable to access 'https://github.com/infection/phpspec-adapter/': The requested URL returned error: 400
  Error: The process '/usr/bin/git' failed with exit code 128
```