### PR TITLE
fix: Correctly detect bailouts

### DIFF
--- a/src/TapTestChecker.php
+++ b/src/TapTestChecker.php
@@ -36,8 +36,10 @@ declare(strict_types=1);
 namespace Infection\TestFramework\PhpSpec;
 
 use function explode;
+use function ltrim;
 use const PHP_EOL;
 use function preg_match;
+use function str_starts_with;
 
 /**
  * Minimal implementation that can tell if the tests passed or not from a TAP output.
@@ -65,6 +67,10 @@ readonly class TapTestChecker
             if (preg_match('%not ok \\d+ - %', $line) > 0
                 && preg_match('%# TODO%', $line) === 0
             ) {
+                return false;
+            }
+
+            if (str_starts_with(ltrim($line), 'Bail out!')) {
                 return false;
             }
         }

--- a/tests/phpunit/TapTestCheckerTest.php
+++ b/tests/phpunit/TapTestCheckerTest.php
@@ -112,6 +112,11 @@ final class TapTestCheckerTest extends TestCase
             false,
         ];
 
+        yield 'TAP result type: bailout with indent' => [
+            '  Bail out!  We ran out of tokens!',
+            false,
+        ];
+
         yield 'TAP result type: unknown' => [
             '... yo, this ain\'t TAP! ...',
             true,

--- a/tests/phpunit/TapTestCheckerTest.php
+++ b/tests/phpunit/TapTestCheckerTest.php
@@ -109,7 +109,7 @@ final class TapTestCheckerTest extends TestCase
 
         yield 'TAP result type: bailout' => [
             'Bail out!  We ran out of tokens!',
-            true,   // TODO: this should return false!
+            false,
         ];
 
         yield 'TAP result type: unknown' => [


### PR DESCRIPTION
Note that this is currently a completely theoritical case as PhpSpec doesn't allow such bailouts.