### PR TITLE
fix: Require at least one passing test for the test output to be considered as valid

### DIFF
--- a/src/TapTestChecker.php
+++ b/src/TapTestChecker.php
@@ -61,6 +61,8 @@ readonly class TapTestChecker
      */
     public function testsPass(string $output): bool
     {
+        $hasAtLeastOnceSuccessfulTest = false;
+
         $lines = explode(PHP_EOL, $output);
 
         foreach ($lines as $line) {
@@ -70,8 +72,14 @@ readonly class TapTestChecker
                 return false;
             }
 
-            if (str_starts_with(ltrim($line), 'Bail out!')) {
+            $leftTrimmedLine = ltrim($line);
+
+            if (str_starts_with($leftTrimmedLine, 'Bail out!')) {
                 return false;
+            }
+
+            if (str_starts_with($leftTrimmedLine, 'ok ')) {
+                $hasAtLeastOnceSuccessfulTest = true;
             }
         }
 
@@ -81,6 +89,6 @@ readonly class TapTestChecker
             }
         }
 
-        return true;
+        return $hasAtLeastOnceSuccessfulTest;
     }
 }

--- a/tests/phpunit/TapTestCheckerTest.php
+++ b/tests/phpunit/TapTestCheckerTest.php
@@ -62,23 +62,55 @@ final class TapTestCheckerTest extends TestCase
     {
         yield 'TAP result type: version' => [
             'TAP version 12',
+            false,
+        ];
+
+        yield 'TAP result type: version (with a passing test)' => [
+            <<<'TAP_OUTPUT'
+                TAP version 12
+                ok This is just to show we do not fail on this statement
+                TAP_OUTPUT,
             true,
         ];
 
         yield 'TAP result type: plan' => [
             '1..42',
+            false,
+        ];
+
+        yield 'TAP result type: plan (with a passing test)' => [
+            <<<'TAP_OUTPUT'
+                1..42
+                ok This is just to show we do not fail on this statement
+                TAP_OUTPUT,
             true,
         ];
 
         yield 'TAP result type: pragma; turn on strict mode' => [
             // Not really used in the PHP community
             'pragma +strict',
+            false,
+        ];
+
+        yield 'TAP result type: pragma; turn on strict mode (with a passing test)' => [
+            <<<'TAP_OUTPUT'
+                pragma +strict
+                ok This is just to show we do not fail on this statement
+                TAP_OUTPUT,
             true,
         ];
 
         yield 'TAP result type: pragma; disable feature' => [
             // Not really used in the PHP community
             'pragma -foo',
+            false,
+        ];
+
+        yield 'TAP result type: pragma; disable feature (with a passing test)' => [
+            <<<'TAP_OUTPUT'
+                pragma -foo
+                ok This is just to show we do not fail on this statement
+                TAP_OUTPUT,
             true,
         ];
 
@@ -99,16 +131,40 @@ final class TapTestCheckerTest extends TestCase
 
         yield 'TAP result type: failing test with a directive' => [
             'not ok 17 - Pigs can fly # TODO not enough acid!',
+            false,
+        ];
+
+        yield 'AP result type: failing test with a directive (with a passing test)' => [
+            <<<'TAP_OUTPUT'
+                not ok 17 - Pigs can fly # TODO not enough acid!
+                ok This is just to show we do not fail on this statement
+                TAP_OUTPUT,
             true,
         ];
 
         yield 'TAP result type: comment' => [
             '# Hope we don\'t use up all of our tokens.',
+            false,
+        ];
+
+        yield 'TAP result type: comment (with a passing test)' => [
+            <<<'TAP_OUTPUT'
+                # Hope we don\'t use up all of our tokens.
+                ok This is just to show we do not fail on this statement
+                TAP_OUTPUT,
             true,
         ];
 
         yield 'TAP result type: bailout' => [
             'Bail out!  We ran out of tokens!',
+            false,
+        ];
+
+        yield 'TAP result type: bailout (with a passing test)' => [
+            <<<'TAP_OUTPUT'
+                Bail out!  We ran out of tokens!
+                ok This is just to show we do not fail on this statement
+                TAP_OUTPUT,
             false,
         ];
 
@@ -119,6 +175,14 @@ final class TapTestCheckerTest extends TestCase
 
         yield 'TAP result type: unknown' => [
             '... yo, this ain\'t TAP! ...',
+            false,
+        ];
+
+        yield 'TAP result type: unknown (with a passing test)' => [
+            <<<'TAP_OUTPUT'
+                ... yo, this ain\'t TAP! ...
+                ok This is just to show we do not fail on this statement
+                TAP_OUTPUT,
             true,
         ];
 
@@ -129,7 +193,7 @@ final class TapTestCheckerTest extends TestCase
                 severity: fail
                 ...
                 TAP_OUTPUT,
-            true,   // We do not fail on the diagnostic itself
+            false,
         ];
 
         yield 'TAP v13 specific: YAML block for better diagnostic (complete example)' => [

--- a/tests/phpunit/TapTestCheckerTest.php
+++ b/tests/phpunit/TapTestCheckerTest.php
@@ -119,6 +119,11 @@ final class TapTestCheckerTest extends TestCase
             true,
         ];
 
+        yield 'TAP result type: successful (indented) test' => [
+            '  ok 3 - We should start with some Hello world!',
+            true,
+        ];
+
         yield 'TAP result type: successful test with a directive' => [
             'ok 3 - We should start with some Hello world! # TODO passed!',
             true,


### PR DESCRIPTION
This change allows to more reliably detect failures without knowing the specific implementations. For example PhpSpec
doesn't handle the TAP bailouts correctly (most likely because hard to do in PHP when working with the main process). Yet, this allows to correctly detect that the test suite failed, just because for it to pass we need at least one passing test.

In theory it is a big change because when previously a test suite was completely skipped or no test is executed, it would pass and won't anymore.

In practice however, this is unlikely to cause any big change as if there wasn't any test in the first place, the code wouldn't be considered covered by a test framework hence not mutated.
