### PR TITLE
refactor: Inject the adapter name via the factory

### DIFF
--- a/src/PhpSpecAdapter.php
+++ b/src/PhpSpecAdapter.php
@@ -51,6 +51,7 @@ final readonly class PhpSpecAdapter implements TestFrameworkAdapter
     public const COVERAGE_DIR = 'phpspec-coverage-xml';
 
     public function __construct(
+        private string $name,
         private string $testFrameworkExecutable,
         private InitialConfigBuilder $initialConfigBuilder,
         private MutationConfigBuilder $mutationConfigBuilder,
@@ -73,7 +74,7 @@ final readonly class PhpSpecAdapter implements TestFrameworkAdapter
 
     public function getName(): string
     {
-        return 'PhpSpec';
+        return $this->name;
     }
 
     public function getInitialTestRunCommandLine(

--- a/src/PhpSpecAdapterFactory.php
+++ b/src/PhpSpecAdapterFactory.php
@@ -53,6 +53,8 @@ use Symfony\Component\Yaml\Yaml;
 
 final readonly class PhpSpecAdapterFactory implements TestFrameworkAdapterFactory
 {
+    private const NAME = 'PhpSpec';
+
     /**
      * @param string[] $sourceDirectories
      */
@@ -88,6 +90,7 @@ final readonly class PhpSpecAdapterFactory implements TestFrameworkAdapterFactor
         $commandLineBuilder = new CommandLineBuilder();
 
         return new PhpSpecAdapter(
+            self::NAME,
             $testFrameworkExecutable,
             new InitialConfigBuilder(
                 $tmpDir,
@@ -106,7 +109,7 @@ final readonly class PhpSpecAdapterFactory implements TestFrameworkAdapterFactor
                 new ProcessVersionProvider(
                     $testFrameworkExecutable,
                     $commandLineBuilder,
-                    new VersionParser(),
+                    new VersionParser(self::NAME),
                 ),
             ),
             $commandLineBuilder,

--- a/src/Version/VersionParser.php
+++ b/src/Version/VersionParser.php
@@ -54,6 +54,11 @@ final readonly class VersionParser
     //   - dd = day
     private const VERSION_REGEX = '/(?:.+ [vV]?)?(?<version>(?P<major>0|[1-9]\d*)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:\.\d+)?(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?: .+)?/';
 
+    public function __construct(
+        private string $name,
+    ) {
+    }
+
     /**
      * Parses a string value to try to extract the exact version out of it. The input can
      * typically be the output of `$ tool --version`, which usually may include information
@@ -70,7 +75,7 @@ final readonly class VersionParser
 
         if (!$matched) {
             throw InvalidVersionFactory::create(
-                'PhpSpec',
+                $this->name,
                 $value,
             );
         }

--- a/tests/phpunit/PhpSpecAdapterTest.php
+++ b/tests/phpunit/PhpSpecAdapterTest.php
@@ -55,7 +55,7 @@ final class PhpSpecAdapterTest extends TestCase
     {
         $adapter = $this->getAdapter();
 
-        $this->assertSame('PhpSpec', $adapter->getName());
+        $this->assertSame('PhpSpecAdapterTest', $adapter->getName());
     }
 
     public function test_it_determines_when_tests_pass(): void
@@ -127,6 +127,7 @@ final class PhpSpecAdapterTest extends TestCase
             ->willReturn(['/path/to/phpspec', '--dummy-argument']);
 
         $adapter = new PhpSpecAdapter(
+            'PhpSpecAdapterTest',
             '/path/to/phpspec',
             $initialConfigBuilderMock,
             $this->createMock(MutationConfigBuilder::class),
@@ -188,6 +189,7 @@ final class PhpSpecAdapterTest extends TestCase
             ->willReturn(['/path/to/phpspec', '--dummy-argument']);
 
         $adapter = new PhpSpecAdapter(
+            'PhpSpecAdapterTest',
             '/path/to/phpspec',
             $this->createMock(InitialConfigBuilder::class),
             $mutationConfigBuilderMock,
@@ -217,6 +219,7 @@ final class PhpSpecAdapterTest extends TestCase
     private function getAdapter(): PhpSpecAdapter
     {
         return new PhpSpecAdapter(
+            'PhpSpecAdapterTest',
             '/path/to/phpspec',
             $this->createMock(InitialConfigBuilder::class),
             $this->createMock(MutationConfigBuilder::class),

--- a/tests/phpunit/Version/ProcessVersionProviderTest.php
+++ b/tests/phpunit/Version/ProcessVersionProviderTest.php
@@ -64,7 +64,7 @@ final class ProcessVersionProviderTest extends TestCase
         $provider = new ProcessVersionProvider(
             self::PHPSPEC_PHAR,
             new CommandLineBuilder(),
-            new VersionParser(),
+            new VersionParser('PhpSpecAdapterTest'),
         );
 
         $actual = $provider->get();

--- a/tests/phpunit/Version/VersionParserTest.php
+++ b/tests/phpunit/Version/VersionParserTest.php
@@ -50,7 +50,7 @@ final class VersionParserTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->versionParser = new VersionParser();
+        $this->versionParser = new VersionParser('PhpSpec');
     }
 
     #[DataProvider('versionProvider')]


### PR DESCRIPTION
Having `PhpSpecAdapter` provide its name makes total sense. However, I noticed for example `VersionParser` that also needs access to that name somehow to provide a better exception message to the user. Currently it is hardcoded, and it is not a problem.

However, ultimately, I would like `VersionParser` to be re-usable and come from somewhere else, i.e. not implemented from this package. To this end, it is better of the test framework name is injected instead. Since those services are instantiated from the Factory, and the adapter is not meant to be created without its factory anyway, I think it's fine to have the name declared by the adapter factory and injected instead. As a result, we can inject the name to the instantiated services too, regardless of which package they were declared.