### PR TITLE
refactor: Inject the coverage directory from the factory

### DIFF
--- a/infection.json5
+++ b/infection.json5
@@ -10,6 +10,9 @@
     },
     "mutators": {
         "@default": true,
+        "global-ignore": [
+            "Infection\\TestFramework\\PhpSpec\\PhpSpecAdapterFactory::createDefaultCoverageXmlDirectoryPath"
+        ],
 
         "ArrayItemRemoval": {
             "ignore": [

--- a/src/Config/InitialConfigBuilder.php
+++ b/src/Config/InitialConfigBuilder.php
@@ -52,6 +52,7 @@ readonly class InitialConfigBuilder
      */
     public function __construct(
         private string $tmpDirectory,
+        private string $coverageDirectoryPath,
         private array $originalPhpSpecConfigDecodedContents,
         private bool $skipCoverage,
         private Filesystem $filesystem,
@@ -68,7 +69,7 @@ readonly class InitialConfigBuilder
 
         try {
             $configuration = PhpSpecConfigurationBuilder::create(
-                $this->tmpDirectory,
+                $this->coverageDirectoryPath,
                 $this->originalPhpSpecConfigDecodedContents,
             );
         } catch (UnrecognisableConfiguration $exception) {

--- a/src/Config/MutationConfigBuilder.php
+++ b/src/Config/MutationConfigBuilder.php
@@ -87,7 +87,7 @@ readonly class MutationConfigBuilder
 
         try {
             $configuration = PhpSpecConfigurationBuilder::create(
-                $this->tmpDirectory,
+                '/unused',
                 $this->originalPhpSpecConfigDecodedContents,
             );
         } catch (UnrecognisableConfiguration $exception) {

--- a/src/Config/PhpSpecConfigurationBuilder.php
+++ b/src/Config/PhpSpecConfigurationBuilder.php
@@ -37,7 +37,6 @@ namespace Infection\TestFramework\PhpSpec\Config;
 
 use function array_is_list;
 use function array_key_exists;
-use Infection\TestFramework\PhpSpec\PhpSpecAdapter;
 use Infection\TestFramework\PhpSpec\Throwable\NoCodeCoverageConfigured;
 use Infection\TestFramework\PhpSpec\Throwable\UnrecognisableConfiguration;
 use function is_array;
@@ -55,7 +54,7 @@ final class PhpSpecConfigurationBuilder
      * @param DecodedPhpSpecConfig $parsedYaml
      */
     public function __construct(
-        private readonly string $tmpDirectory,
+        private readonly string $coverageDirectoryPath,
         private array $parsedYaml,
     ) {
     }
@@ -66,12 +65,15 @@ final class PhpSpecConfigurationBuilder
      * @throws UnrecognisableConfiguration
      */
     public static function create(
-        string $tmpDirectory,
+        string $coverageDirectoryPath,
         array $parsedYaml,
     ): self {
         self::assertIsSupportedExtensionsFormat($parsedYaml);
 
-        return new self($tmpDirectory, $parsedYaml);
+        return new self(
+            $coverageDirectoryPath,
+            $parsedYaml,
+        );
     }
 
     public function removeCoverageExtension(): void
@@ -99,7 +101,7 @@ final class PhpSpecConfigurationBuilder
             // will be unused.
             $options['format'] = ['xml'];
             $options['output'] = [
-                'xml' => $this->tmpDirectory . '/' . PhpSpecAdapter::COVERAGE_DIR,
+                'xml' => $this->coverageDirectoryPath,
             ];
         }
     }

--- a/src/PhpSpecAdapter.php
+++ b/src/PhpSpecAdapter.php
@@ -48,8 +48,6 @@ use function sprintf;
 
 final readonly class PhpSpecAdapter implements TestFrameworkAdapter
 {
-    public const COVERAGE_DIR = 'phpspec-coverage-xml';
-
     public function __construct(
         private string $name,
         private string $testFrameworkExecutable,

--- a/src/PhpSpecAdapterFactory.php
+++ b/src/PhpSpecAdapterFactory.php
@@ -87,6 +87,8 @@ final readonly class PhpSpecAdapterFactory implements TestFrameworkAdapterFactor
 
         $phpSpecConfigDecodedContents = Yaml::parse($phpSpecConfigContents);
 
+        $coverageDirectoryPath = self::createDefaultCoverageXmlDirectoryPath($tmpDirectory);
+
         $commandLineBuilder = new CommandLineBuilder();
 
         return new PhpSpecAdapter(
@@ -94,6 +96,7 @@ final readonly class PhpSpecAdapterFactory implements TestFrameworkAdapterFactor
             $testFrameworkExecutable,
             new InitialConfigBuilder(
                 $tmpDirectory,
+                $coverageDirectoryPath,
                 $phpSpecConfigDecodedContents,
                 $skipCoverage,
                 $filesystem,
@@ -125,5 +128,10 @@ final readonly class PhpSpecAdapterFactory implements TestFrameworkAdapterFactor
     public static function getExecutableName(): string
     {
         return 'phpspec';
+    }
+
+    private static function createDefaultCoverageXmlDirectoryPath(string $tmpDirectory): string
+    {
+        return $tmpDirectory . '/phpspec-coverage-xml';
     }
 }

--- a/tests/phpunit/Config/InitialConfigBuilderTest.php
+++ b/tests/phpunit/Config/InitialConfigBuilderTest.php
@@ -66,6 +66,7 @@ final class InitialConfigBuilderTest extends TestCase
                 YAML,
         );
         $tmpDirectory = '/path/to/tmp';
+        $coverageDirectoryPath = '/path/to/tmp/phpspec-coverage-xml';
 
         $expectedInitialConfigFilePath = '/path/to/tmp/phpspecConfiguration.initial.infection.yml';
 
@@ -85,6 +86,7 @@ final class InitialConfigBuilderTest extends TestCase
 
         $builder = new InitialConfigBuilder(
             $tmpDirectory,
+            $coverageDirectoryPath,
             $originalPhpSpecConfigDecodedContents,
             false,
             $fileSystemMock,
@@ -115,6 +117,7 @@ final class InitialConfigBuilderTest extends TestCase
 
         $builder = new InitialConfigBuilder(
             '/path/to/tmp',
+            '/path/to/tmp/phpspec-coverage-xml',
             $originalPhpSpecConfigDecodedContents,
             false,
             $fileSystemMock,

--- a/tests/phpunit/Config/PhpSpecConfigurationBuilderTest.php
+++ b/tests/phpunit/Config/PhpSpecConfigurationBuilderTest.php
@@ -48,7 +48,7 @@ use Symfony\Component\Yaml\Yaml;
 #[CoversClass(PhpSpecConfigurationBuilder::class)]
 final class PhpSpecConfigurationBuilderTest extends TestCase
 {
-    private const TMP_DIRECTORY = '/path/to/project';
+    private const COVERAGE_DIRECTORY = '/path/to/project/phpspec-coverage-xml';
 
     #[DataProvider('legacyExtensionFormat')]
     public function test_it_cannot_be_created_with_the_legacy_phpspec_configuration_format(
@@ -60,7 +60,7 @@ final class PhpSpecConfigurationBuilderTest extends TestCase
         }
 
         PhpSpecConfigurationBuilder::create(
-            self::TMP_DIRECTORY,
+            self::COVERAGE_DIRECTORY,
             Yaml::parse($original) ?? [],
         );
 
@@ -138,7 +138,7 @@ final class PhpSpecConfigurationBuilderTest extends TestCase
         string $expected,
     ): void {
         $builder = PhpSpecConfigurationBuilder::create(
-            self::TMP_DIRECTORY,
+            self::COVERAGE_DIRECTORY,
             Yaml::parse($original) ?? [],
         );
 
@@ -346,7 +346,7 @@ final class PhpSpecConfigurationBuilderTest extends TestCase
         string $expected,
     ): void {
         $builder = PhpSpecConfigurationBuilder::create(
-            self::TMP_DIRECTORY,
+            self::COVERAGE_DIRECTORY,
             Yaml::parse($original) ?? [],
         );
 
@@ -566,7 +566,7 @@ final class PhpSpecConfigurationBuilderTest extends TestCase
         string $expected,
     ): void {
         $builder = PhpSpecConfigurationBuilder::create(
-            self::TMP_DIRECTORY,
+            self::COVERAGE_DIRECTORY,
             Yaml::parse($original) ?? [],
         );
 
@@ -667,11 +667,11 @@ final class PhpSpecConfigurationBuilderTest extends TestCase
         $originalDecoded = Yaml::parse($original) ?? [];
 
         $builder1 = PhpSpecConfigurationBuilder::create(
-            '/path/to/tmp',
+            self::COVERAGE_DIRECTORY,
             $originalDecoded,
         );
         $builder2 = PhpSpecConfigurationBuilder::create(
-            '/path/to/tmp',
+            self::COVERAGE_DIRECTORY,
             $originalDecoded,
         );
 
@@ -704,7 +704,7 @@ final class PhpSpecConfigurationBuilderTest extends TestCase
                 extensions:
                     Acme\Extension\FirstExampleExtension: { key1: value1 }
                     Acme\Extension\SecondExampleExtension: { key3: value3 }
-                    FriendsOfPhpSpec\PhpSpec\CodeCoverage\CodeCoverageExtension: { format: [xml], output: { xml: /path/to/tmp/phpspec-coverage-xml } }
+                    FriendsOfPhpSpec\PhpSpec\CodeCoverage\CodeCoverageExtension: { format: [xml], output: { xml: /path/to/project/phpspec-coverage-xml } }
 
                 YAML,
             $result2,


### PR DESCRIPTION
What prompted this is I was curious how infection found the `index.xml` at all in the first place.

Turns out we do not rely at all on the expected `index.xml` path, but we still find the file because we use the finder to lookup in the parent directory.

Using the default path is better because more performant. But knowing it can only be done by `infection`. So to forward this information to the adapters, we need to adapt the factory.

I putted this idea in https://github.com/infection/infection/issues/2760, meanwhile this PR only contents itself with letting the factory define the coverage path used. I will update the coverage path to match with the default one in a separate PR (as it has behaviour changes, it would no longer is a refactoring).

A nice side-effect is that it showcase when we're really using the injected `tmpDirectory` and when we are using the `coverageDirectoryPath`.

