### PR TITLE
perf: Use the default coverage XML path

### DIFF
--- a/src/PhpSpecAdapterFactory.php
+++ b/src/PhpSpecAdapterFactory.php
@@ -132,6 +132,6 @@ final readonly class PhpSpecAdapterFactory implements TestFrameworkAdapterFactor
 
     private static function createDefaultCoverageXmlDirectoryPath(string $tmpDirectory): string
     {
-        return $tmpDirectory . '/phpspec-coverage-xml';
+        return $tmpDirectory . '/coverage-xml';
     }
 }


### PR DESCRIPTION
Follow up of #93.

With this change, the XML index report will no longer need to use the finder as it should match the default location.