### PR TITLE
refactor: Extract the autoload generator to a dedicated service

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13,12 +13,6 @@ parameters:
 			path: src/CommandLine/CommandLineBuilder.php
 
 		-
-			message: '#^PHPDoc tag @var with type string is not subtype of native type literal\-string&non\-falsy\-string\.$#'
-			identifier: varTag.nativeType
-			count: 1
-			path: src/Config/MutationConfigBuilder.php
-
-		-
 			message: '#^Parameter \#7 \$sourceDirectories \(array\<string\>\) of method Infection\\TestFramework\\PhpSpec\\PhpSpecAdapterFactory\:\:create\(\) should be contravariant with parameter \$sourceDirectories \(array\) of method Infection\\AbstractTestFramework\\TestFrameworkAdapterFactory\:\:create\(\)$#'
 			identifier: method.childParameterType
 			count: 1

--- a/src/Config/MutationAutoloadTemplate.php
+++ b/src/Config/MutationAutoloadTemplate.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\TestFramework\PhpSpec\Config;
+
+use function array_key_exists;
+use function assert;
+use Infection\StreamWrapper\IncludeInterceptor;
+use function is_string;
+use Phar;
+use function sprintf;
+use function str_replace;
+use function str_starts_with;
+use function strstr;
+
+/**
+ * @phpstan-import-type DecodedPhpSpecConfig from PhpSpecConfigurationBuilder
+ *
+ * @internal
+ * @final
+ */
+readonly class MutationAutoloadTemplate
+{
+    public function __construct(
+        private string $projectDir,
+    ) {
+    }
+
+    /**
+     * @param DecodedPhpSpecConfig $phpSpecConfig
+     */
+    public function build(
+        string $originalFilePath,
+        string $mutantFilePath,
+        array $phpSpecConfig,
+    ): string {
+        $originalBootstrap = $this->getOriginalBootstrapFilePath($phpSpecConfig);
+        $autoloadPlaceholder = $originalBootstrap !== null
+            ? "require_once '{$originalBootstrap}';"
+            : '';
+        /** @var literal-string&non-falsy-string $interceptorPath */
+        $interceptorPath = IncludeInterceptor::LOCATION;
+
+        $customAutoload = <<<AUTOLOAD
+            <?php
+
+            %s
+            %s
+
+            AUTOLOAD;
+
+        return sprintf(
+            $customAutoload,
+            $autoloadPlaceholder,
+            $this->getInterceptorFileContent(
+                $interceptorPath,
+                $originalFilePath,
+                $mutantFilePath,
+            ),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $parsedYaml
+     */
+    private function getOriginalBootstrapFilePath(array $parsedYaml): ?string
+    {
+        if (!array_key_exists('bootstrap', $parsedYaml)) {
+            return null;
+        }
+
+        return sprintf('%s/%s', $this->projectDir, $parsedYaml['bootstrap']);
+    }
+
+    private function getInterceptorFileContent(
+        string $interceptorPath,
+        string $originalFilePath,
+        string $mutantFilePath,
+    ): string {
+        $infectionPhar = '';
+
+        if (str_starts_with(__FILE__, 'phar:')) {
+            $infectionPhar = sprintf(
+                '\Phar::loadPhar("%s", "%s");',
+                str_replace(
+                    'phar://',
+                    '',
+                    Phar::running(true),
+                ),
+                'infection.phar',
+            );
+        }
+
+        $namespacePrefix = $this->getInterceptorNamespacePrefix();
+
+        return <<<CONTENT
+            {$infectionPhar}
+            require_once '{$interceptorPath}';
+
+            use {$namespacePrefix}Infection\StreamWrapper\IncludeInterceptor;
+
+            IncludeInterceptor::intercept('{$originalFilePath}', '{$mutantFilePath}');
+            IncludeInterceptor::enable();
+            CONTENT;
+    }
+
+    private function getInterceptorNamespacePrefix(): string
+    {
+        $prefix = strstr(__NAMESPACE__, 'Infection', true);
+        assert(is_string($prefix));
+
+        return $prefix;
+    }
+}

--- a/src/Config/MutationAutoloadTemplate.php
+++ b/src/Config/MutationAutoloadTemplate.php
@@ -49,12 +49,11 @@ use function strstr;
  * @phpstan-import-type DecodedPhpSpecConfig from PhpSpecConfigurationBuilder
  *
  * @internal
- * @final
  */
-readonly class MutationAutoloadTemplate
+final readonly class MutationAutoloadTemplate
 {
     public function __construct(
-        private string $projectDir,
+        private string $projectDirectory,
     ) {
     }
 
@@ -70,7 +69,6 @@ readonly class MutationAutoloadTemplate
         $autoloadPlaceholder = $originalBootstrap !== null
             ? "require_once '{$originalBootstrap}';"
             : '';
-        /** @var literal-string&non-falsy-string $interceptorPath */
         $interceptorPath = IncludeInterceptor::LOCATION;
 
         $customAutoload = <<<AUTOLOAD
@@ -101,7 +99,7 @@ readonly class MutationAutoloadTemplate
             return null;
         }
 
-        return sprintf('%s/%s', $this->projectDir, $parsedYaml['bootstrap']);
+        return sprintf('%s/%s', $this->projectDirectory, $parsedYaml['bootstrap']);
     }
 
     private function getInterceptorFileContent(

--- a/src/PhpSpecAdapterFactory.php
+++ b/src/PhpSpecAdapterFactory.php
@@ -104,7 +104,7 @@ final readonly class PhpSpecAdapterFactory implements TestFrameworkAdapterFactor
             new MutationConfigBuilder(
                 $tmpDirectory,
                 $phpSpecConfigDecodedContents,
-                $projectDir,
+                new Config\MutationAutoloadTemplate($projectDir),
                 $filesystem,
             ),
             new ArgumentsAndOptionsBuilder(),

--- a/src/PhpSpecAdapterFactory.php
+++ b/src/PhpSpecAdapterFactory.php
@@ -41,6 +41,7 @@ use Infection\AbstractTestFramework\TestFrameworkAdapterFactory;
 use Infection\TestFramework\PhpSpec\CommandLine\ArgumentsAndOptionsBuilder;
 use Infection\TestFramework\PhpSpec\CommandLine\CommandLineBuilder;
 use Infection\TestFramework\PhpSpec\Config\InitialConfigBuilder;
+use Infection\TestFramework\PhpSpec\Config\MutationAutoloadTemplate;
 use Infection\TestFramework\PhpSpec\Config\MutationConfigBuilder;
 use Infection\TestFramework\PhpSpec\Version\CachedVersionProvider;
 use Infection\TestFramework\PhpSpec\Version\ProcessVersionProvider;
@@ -64,7 +65,7 @@ final readonly class PhpSpecAdapterFactory implements TestFrameworkAdapterFactor
         string $testFrameworkConfigPath,
         ?string $testFrameworkConfigDir,
         string $jUnitFilePath,
-        string $projectDir,
+        string $projectDirectory,
         array $sourceDirectories,
         bool $skipCoverage,
     ): TestFrameworkAdapter {
@@ -104,7 +105,7 @@ final readonly class PhpSpecAdapterFactory implements TestFrameworkAdapterFactor
             new MutationConfigBuilder(
                 $tmpDirectory,
                 $phpSpecConfigDecodedContents,
-                new Config\MutationAutoloadTemplate($projectDir),
+                new MutationAutoloadTemplate($projectDirectory),
                 $filesystem,
             ),
             new ArgumentsAndOptionsBuilder(),

--- a/tests/phpunit/Config/MutationAutoloadTemplateTest.php
+++ b/tests/phpunit/Config/MutationAutoloadTemplateTest.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\TestFramework\PhpSpec\Config;
+
+use Infection\StreamWrapper\IncludeInterceptor;
+use Infection\TestFramework\PhpSpec\Config\MutationAutoloadTemplate;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+#[CoversClass(MutationAutoloadTemplate::class)]
+final class MutationAutoloadTemplateTest extends TestCase
+{
+    private const ORIGINAL_FILE_PATH = '/original/file/path';
+
+    private const MUTATED_FILE_PATH = '/mutated/file/path';
+
+    /**
+     * @param array<string, mixed> $phpSpecConfig
+     */
+    #[DataProvider('autoloadTemplateProvider')]
+    public function test_it_generates_autoload_template(
+        string $projectDir,
+        array $phpSpecConfig,
+        ?string $expectedBootstrapRequire,
+    ): void {
+        $template = new MutationAutoloadTemplate($projectDir);
+
+        $actualContent = $template->build(
+            self::ORIGINAL_FILE_PATH,
+            self::MUTATED_FILE_PATH,
+            $phpSpecConfig,
+        );
+
+        $interceptorPath = IncludeInterceptor::LOCATION;
+        $bootstrapSection = $expectedBootstrapRequire !== null
+            ? "require_once '{$expectedBootstrapRequire}';\n\n"
+            : "\n\n";
+
+        $expectedContent = <<<PHP
+            <?php
+
+            {$bootstrapSection}require_once '{$interceptorPath}';
+
+            use Infection\StreamWrapper\IncludeInterceptor;
+
+            IncludeInterceptor::intercept('/original/file/path', '/mutated/file/path');
+            IncludeInterceptor::enable();
+
+            PHP;
+
+        $this->assertSame($expectedContent, $actualContent);
+    }
+
+    /**
+     * @return iterable<string, array{string, array<string, mixed>, string|null}>
+     */
+    public static function autoloadTemplateProvider(): iterable
+    {
+        yield 'with bootstrap file' => [
+            '/project/dir',
+            Yaml::parse(
+                <<<'YAML'
+                    bootstrap: bootstrap.php
+                    extensions:
+                        CodeCoverageExtension: ~
+                        TestExtension:
+                            options: 123
+                    YAML,
+            ),
+            '/project/dir/bootstrap.php',
+        ];
+
+        yield 'without bootstrap file' => [
+            '/project/dir',
+            Yaml::parse(
+                <<<'YAML'
+                    extensions:
+                        CodeCoverageExtension: ~
+                        TestExtension:
+                            options: 123
+                    YAML,
+            ),
+            null,
+        ];
+
+        yield 'with inline config without bootstrap' => [
+            '/project/dir',
+            Yaml::parse(
+                <<<'YAML'
+                    suites:
+                        default:
+                            namespace: Infection\PhpSpecAdapter\E2ETests\PhpSpec
+                            psr4_prefix: Infection\PhpSpecAdapter\E2ETests\PhpSpec
+                    YAML,
+            ),
+            null,
+        ];
+    }
+}


### PR DESCRIPTION
While looking at the implementation, I saw two things:

- It looks like a few operations are independent from the mutation, hence repeated for no reason.
- "custom autoload with interceptor" was not quite clear, I mean sure it's custom, but I don't know, it doesn't sound nice. I figured "mutation autoload" sounds nicer.

In this PR, I introduce the `MutationAutoloadTemplate`. The implementation remains unchanged, but the tests were updated to be more exhaustive. Any optimization will be done later.
