### PR TITLE
perf: Make the mutation autoload template compute only what is necessary

### DIFF
--- a/src/Config/MutationAutoloadTemplate.php
+++ b/src/Config/MutationAutoloadTemplate.php
@@ -111,7 +111,7 @@ final readonly class MutationAutoloadTemplate
     }
 
     /**
-     * @param DecodedPhpSpecConfig $parsedYaml
+     * @param array<string, mixed> $parsedYaml
      */
     private static function getOriginalBootstrapFilePath(
         string $projectDirectory,

--- a/src/Config/MutationAutoloadTemplate.php
+++ b/src/Config/MutationAutoloadTemplate.php
@@ -52,38 +52,58 @@ use function strstr;
  */
 final readonly class MutationAutoloadTemplate
 {
-    public function __construct(
-        private string $projectDirectory,
+    private const TEMPLATE = <<<'PHP'
+        <?php
+
+        %s
+        %s
+
+        PHP;
+
+    private function __construct(
+        private string $autoloadPlaceholder,
+        private string $interceptorPath,
+        private string $infectionPhar,
+        private string $interceptorNamespacePrefix,
     ) {
     }
 
     /**
      * @param DecodedPhpSpecConfig $phpSpecConfig
      */
-    public function build(
-        string $originalFilePath,
-        string $mutantFilePath,
+    public static function create(
+        string $projectDirectory,
         array $phpSpecConfig,
-    ): string {
-        $originalBootstrap = $this->getOriginalBootstrapFilePath($phpSpecConfig);
+    ): self {
+        $originalBootstrap = self::getOriginalBootstrapFilePath(
+            $projectDirectory,
+            $phpSpecConfig,
+        );
+
         $autoloadPlaceholder = $originalBootstrap !== null
             ? "require_once '{$originalBootstrap}';"
             : '';
         $interceptorPath = IncludeInterceptor::LOCATION;
 
-        $customAutoload = <<<AUTOLOAD
-            <?php
+        $infectionPhar = self::getLoadInfectionPhar();
+        $interceptorNamespacePrefix = self::getInterceptorNamespacePrefix();
 
-            %s
-            %s
-
-            AUTOLOAD;
-
-        return sprintf(
-            $customAutoload,
+        return new self(
             $autoloadPlaceholder,
+            $interceptorPath,
+            $infectionPhar,
+            $interceptorNamespacePrefix,
+        );
+    }
+
+    public function build(
+        string $originalFilePath,
+        string $mutantFilePath,
+    ): string {
+        return sprintf(
+            self::TEMPLATE,
+            $this->autoloadPlaceholder,
             $this->getInterceptorFileContent(
-                $interceptorPath,
                 $originalFilePath,
                 $mutantFilePath,
             ),
@@ -91,26 +111,40 @@ final readonly class MutationAutoloadTemplate
     }
 
     /**
-     * @param array<string, mixed> $parsedYaml
+     * @param DecodedPhpSpecConfig $parsedYaml
      */
-    private function getOriginalBootstrapFilePath(array $parsedYaml): ?string
-    {
-        if (!array_key_exists('bootstrap', $parsedYaml)) {
-            return null;
-        }
-
-        return sprintf('%s/%s', $this->projectDirectory, $parsedYaml['bootstrap']);
+    private static function getOriginalBootstrapFilePath(
+        string $projectDirectory,
+        array $parsedYaml,
+    ): ?string {
+        return array_key_exists('bootstrap', $parsedYaml)
+            ? sprintf(
+                '%s/%s',
+                $projectDirectory,
+                $parsedYaml['bootstrap'],
+            )
+            : null;
     }
 
     private function getInterceptorFileContent(
-        string $interceptorPath,
         string $originalFilePath,
         string $mutantFilePath,
     ): string {
-        $infectionPhar = '';
+        return <<<CONTENT
+            {$this->infectionPhar}
+            require_once '{$this->interceptorPath}';
 
+            use {$this->interceptorNamespacePrefix}Infection\StreamWrapper\IncludeInterceptor;
+
+            IncludeInterceptor::intercept('{$originalFilePath}', '{$mutantFilePath}');
+            IncludeInterceptor::enable();
+            CONTENT;
+    }
+
+    private static function getLoadInfectionPhar(): string
+    {
         if (str_starts_with(__FILE__, 'phar:')) {
-            $infectionPhar = sprintf(
+            return sprintf(
                 '\Phar::loadPhar("%s", "%s");',
                 str_replace(
                     'phar://',
@@ -121,20 +155,10 @@ final readonly class MutationAutoloadTemplate
             );
         }
 
-        $namespacePrefix = $this->getInterceptorNamespacePrefix();
-
-        return <<<CONTENT
-            {$infectionPhar}
-            require_once '{$interceptorPath}';
-
-            use {$namespacePrefix}Infection\StreamWrapper\IncludeInterceptor;
-
-            IncludeInterceptor::intercept('{$originalFilePath}', '{$mutantFilePath}');
-            IncludeInterceptor::enable();
-            CONTENT;
+        return '';
     }
 
-    private function getInterceptorNamespacePrefix(): string
+    private static function getInterceptorNamespacePrefix(): string
     {
         $prefix = strstr(__NAMESPACE__, 'Infection', true);
         assert(is_string($prefix));

--- a/src/Config/MutationConfigBuilder.php
+++ b/src/Config/MutationConfigBuilder.php
@@ -98,7 +98,6 @@ readonly class MutationConfigBuilder
             $this->autoloadTemplate->build(
                 $mutationOriginalFilePath,
                 $mutantFilePath,
-                $this->originalPhpSpecConfigDecodedContents,
             ),
         );
         $this->filesystem->dumpFile($path, $newYaml);

--- a/src/PhpSpecAdapterFactory.php
+++ b/src/PhpSpecAdapterFactory.php
@@ -105,7 +105,10 @@ final readonly class PhpSpecAdapterFactory implements TestFrameworkAdapterFactor
             new MutationConfigBuilder(
                 $tmpDirectory,
                 $phpSpecConfigDecodedContents,
-                new MutationAutoloadTemplate($projectDirectory),
+                MutationAutoloadTemplate::create(
+                    $projectDirectory,
+                    $phpSpecConfigDecodedContents,
+                ),
                 $filesystem,
             ),
             new ArgumentsAndOptionsBuilder(),

--- a/tests/phpunit/Config/MutationAutoloadTemplateTest.php
+++ b/tests/phpunit/Config/MutationAutoloadTemplateTest.php
@@ -58,12 +58,14 @@ final class MutationAutoloadTemplateTest extends TestCase
         array $phpSpecConfig,
         string $expected,
     ): void {
-        $template = new MutationAutoloadTemplate($projectDirectory);
+        $template = MutationAutoloadTemplate::create(
+            $projectDirectory,
+            $phpSpecConfig,
+        );
 
         $actual = $template->build(
             self::ORIGINAL_FILE_PATH,
             self::MUTATED_FILE_PATH,
-            $phpSpecConfig,
         );
 
         $this->assertSame($expected, $actual);

--- a/tests/phpunit/Config/MutationConfigBuilderTest.php
+++ b/tests/phpunit/Config/MutationConfigBuilderTest.php
@@ -39,12 +39,10 @@ use Infection\TestFramework\PhpSpec\Config\MutationAutoloadTemplate;
 use Infection\TestFramework\PhpSpec\Config\MutationConfigBuilder;
 use Infection\TestFramework\PhpSpec\Throwable\UnrecognisableConfiguration;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Yaml\Yaml;
 
-#[Group('integration')]
 #[CoversClass(MutationConfigBuilder::class)]
 final class MutationConfigBuilderTest extends TestCase
 {
@@ -108,7 +106,10 @@ final class MutationConfigBuilderTest extends TestCase
         $builder = new MutationConfigBuilder(
             '/path/to/tmp',
             $originalPhpSpecConfigDecodedContents,
-            new MutationAutoloadTemplate($projectDir),
+            MutationAutoloadTemplate::create(
+                $projectDir,
+                $originalPhpSpecConfigDecodedContents,
+            ),
             $fileSystemMock,
         );
 
@@ -148,7 +149,10 @@ final class MutationConfigBuilderTest extends TestCase
         $builder = new MutationConfigBuilder(
             '/path/to/tmp',
             $originalPhpSpecConfigDecodedContents,
-            new MutationAutoloadTemplate('/path/to/project'),
+            MutationAutoloadTemplate::create(
+                '/path/to/project',
+                $originalPhpSpecConfigDecodedContents,
+            ),
             $fileSystemMock,
         );
 


### PR DESCRIPTION
A good chunk of the mutation autoload template does not depend on the mutation itself. In this PR, I introduce a `::create()` factory method where we do the computation that is not bound to the mutation, hence which should be done once.