### PR TITLE
ci: Fix the update workflow

### DIFF
--- a/.github/workflows/cs.yaml
+++ b/.github/workflows/cs.yaml
@@ -9,6 +9,7 @@ on:
     branches:
       - main
       - master
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/mutation-testing.yaml
+++ b/.github/workflows/mutation-testing.yaml
@@ -9,6 +9,7 @@ on:
     branches:
       - main
       - master
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -10,8 +10,8 @@ on:
   workflow_dispatch: # Allow manual triggering
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: write       # Required to create a new branch and commit the changes
+  pull-requests: write  # Required to create the PR
 
 jobs:
   update-tool-version:
@@ -71,7 +71,7 @@ jobs:
         uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: chore/update-${{ matrix.tool.name }}-${{ steps.latest-release.outputs.version }}
+          branch: chore/update-${{ matrix.tool.name }}
           delete-branch: true
           commit-message: |
             chore: Update ${{ matrix.tool.name }} to ${{ steps.latest-release.outputs.version }}
@@ -84,3 +84,22 @@ jobs:
             ---
 
             This PR was automatically created by the [Update Tool Versions workflow](.github/workflows/update.yaml).
+
+      - name: Display GitHub CLI version
+        if: steps.compare.outputs.needs_update == 'true'
+        run: gh --version
+
+      - name: Trigger CI workflows
+        if: steps.compare.outputs.needs_update == 'true'
+        run: |
+          BRANCH="chore/update-${{ matrix.tool.name }}"
+
+          echo "Triggering CI workflows for branch: $BRANCH"
+
+          gh workflow run cs.yaml --ref "$BRANCH"
+          gh workflow run tests.yaml --ref "$BRANCH"
+          gh workflow run mutation-testing.yaml --ref "$BRANCH"
+
+          echo "CI workflows triggered successfully"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Allow a workflow to trigger the test workflows. [^1]
- Adjusted the branch name: if a new version of the tool is published since the last update and the update workflow is triggered again, this allows to update the existing PR instead of opening a new one.
- Document why we need the permissions in the update workflow for clarity.
- Trigger the checks workflows upon the creation of the PR. I opted to use `gh` as otherwise we would need a personal access token (which is bound to the creator) or create a bot account (which is annoying).


[^1]: By default GitHub disables those. The reasons are it may trigger an infinite loop (update triggers all workflows -> update workflow is triggered again -> triggers all workflows again) or permissions escalation (PR with limited permissions -> triggers prod deployment workflow). We have neither of those problems hence it is safe.