### PR TITLE
ci: Adapt the update tools workflow to allow a PAT

### DIFF
--- a/.github/workflows/cs.yaml
+++ b/.github/workflows/cs.yaml
@@ -9,7 +9,6 @@ on:
     branches:
       - main
       - master
-  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/mutation-testing.yaml
+++ b/.github/workflows/mutation-testing.yaml
@@ -9,7 +9,6 @@ on:
     branches:
       - main
       - master
-  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -10,9 +10,7 @@ on:
   workflow_dispatch: # Allow manual triggering
 
 permissions:
-  contents: write       # Required to create a new branch and commit the changes
-  pull-requests: write  # Required to create the PR
-  actions: write        # Required to trigger workflow dispatch events
+  contents: read  # Required to checkout the repository
 
 jobs:
   update-tool-version:
@@ -71,7 +69,7 @@ jobs:
         if: steps.compare.outputs.needs_update == 'true'
         uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_TOKEN }}
           branch: chore/update-${{ matrix.tool.name }}
           delete-branch: true
           commit-message: |
@@ -85,22 +83,3 @@ jobs:
             ---
 
             This PR was automatically created by the [Update Tool Versions workflow](.github/workflows/update.yaml).
-
-      - name: Display GitHub CLI version
-        if: steps.compare.outputs.needs_update == 'true'
-        run: gh --version
-
-      - name: Trigger CI workflows
-        if: steps.compare.outputs.needs_update == 'true'
-        run: |
-          BRANCH="chore/update-${{ matrix.tool.name }}"
-
-          echo "Triggering CI workflows for branch: $BRANCH"
-
-          gh workflow run cs.yaml --ref "$BRANCH"
-          gh workflow run tests.yaml --ref "$BRANCH"
-          gh workflow run mutation-testing.yaml --ref "$BRANCH"
-
-          echo "CI workflows triggered successfully"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
In #103 and #105 I tried to update the workflow so that the PR created for updating a tool triggers the PR checks.

Unfortunately this does not work, so I don't see any other option than using a Personal Access Token (PAT). This PR updates the workflow to add one.