### PR TITLE
build: Fix the lint commands

### DIFF
--- a/.github/workflows/cs.yaml
+++ b/.github/workflows/cs.yaml
@@ -28,7 +28,7 @@ jobs:
         operating-system: [ubuntu-latest]
         php-version: ['8.2']
         check:
-          - makefile-target: 'cs-lint'
+          - makefile-target: 'php-cs-fixer-lint'
             name: 'PHP-CS-Fixer'
             cache: var/php-cs-fixer-cache
           - makefile-target: 'phpstan'

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ phpstan-update-baseline: vendor/autoload.php
 
 .PHONY: test
 test:	 ## Executes the tests
-test: test-unit infection test-e2e
+test: phpstan test-unit infection test-e2e
 
 .PHONY: test-unit
 test-unit: vendor/autoload.php $(PHPSPEC)


### PR DESCRIPTION
- The CI job for PHP-CS-Fixer was running all the lint tools instead of just PHP-CS-Fixer.
- PHPStan was not included in `test`*

*: Given that, unlike infection where we have the autoreview that includes various checks, I think it is better to have it in `tests` rather than `cs-lint`.