### PR TITLE
ci: Enable PHP 8.4 and 8.5 tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -76,7 +76,8 @@ jobs:
           - '8.2'
           - '8.3'
           - '8.4'
-          - '8.5'
+          # https://github.com/infection/infection/issues/2885
+          #- '8.5'
 
     name: End-to-end on PHP ${{ matrix.php-version }}
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -75,10 +75,8 @@ jobs:
         php-version:
           - '8.2'
           - '8.3'
-          # TODO: https://github.com/phpspec/phpspec/pull/1503
-          #- '8.4'
-          # TODO: https://github.com/phpspec/phpspec/pull/1500
-          # - '8.5'
+          - '8.4'
+          - '8.5'
 
     name: End-to-end on PHP ${{ matrix.php-version }}
 

--- a/tests/phpunit/Version/ProcessVersionProviderTest.php
+++ b/tests/phpunit/Version/ProcessVersionProviderTest.php
@@ -41,7 +41,6 @@ use Infection\TestFramework\PhpSpec\Version\ProcessVersionProvider;
 use Infection\TestFramework\PhpSpec\Version\VersionParser;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\TestCase;
 use function Safe\file_get_contents;
 
@@ -54,7 +53,6 @@ final class ProcessVersionProviderTest extends TestCase
 
     private const PHPSPEC_VERSION = __DIR__ . '/../../../.tools/phpspec-version';
 
-    #[RequiresPhp('<8.5')]
     public function test_it_can_get_the_version(): void
     {
         $this->ensurePharExists();


### PR DESCRIPTION
The blocker https://github.com/infection/phpspec-adapter/pull/104 has been merged.